### PR TITLE
feat(bootstrap): set zsh as default shell if already installed

### DIFF
--- a/bootstrap/install-zsh.sh
+++ b/bootstrap/install-zsh.sh
@@ -14,6 +14,15 @@ has()     { command -v "$1" &>/dev/null; }
 
 if has zsh; then
   success "ZSH already installed: $(zsh --version)"
+  # Ensure zsh is the default shell even when it was pre-installed
+  if [[ "$SHELL" != "$(which zsh)" ]]; then
+    log "ZSH is installed but not the default shell. Setting it as default..."
+    if chsh -s "$(which zsh)"; then
+      success "Default shell changed to ZSH (restart session to apply)"
+    else
+      log "Could not auto-change shell. Run: chsh -s $(which zsh)"
+    fi
+  fi
   exit 0
 fi
 
@@ -34,9 +43,9 @@ fi
 
 success "ZSH installed: $(zsh --version)"
 
-# Offer to change default shell
+# Set zsh as the default shell
 if [[ "$SHELL" != "$(which zsh)" ]]; then
-  log "Changing default shell to ZSH..."
+  log "Setting default shell to ZSH..."
   if chsh -s "$(which zsh)"; then
     success "Default shell changed to ZSH (restart session to apply)"
   else


### PR DESCRIPTION
Previously, the default shell was only updated when zsh was freshly installed. This change ensures that if zsh is already present but is not the current default shell, chsh is called to make it the default during bootstrap.

Closes #1

## Description

<!-- Describe what this PR does and why -->

## Type of change

- [x] `feat` — New feature (triggers minor version bump)
- [ ] `fix` — Bug fix (triggers patch version bump)
- [ ] `docs` — Documentation only
- [ ] `refactor` — Code refactoring, no functional change
- [ ] `ci` — CI/CD changes
- [ ] `chore` — Maintenance tasks
- [ ] `BREAKING CHANGE` — Breaking change (triggers major version bump)

## Checklist

- [x] I followed [Conventional Commits](https://www.conventionalcommits.org/) for all commit messages
- [ ] Shell scripts pass `bash -n` (no syntax errors)
- [ ] Changes are idempotent (safe to run multiple times)
- [ ] Tested on Linux (and macOS if applicable)
- [ ] README updated if needed

## Testing

<!-- Describe how you tested this change -->
