### PR TITLE
feat(cli): add p10k config import subcommand

### DIFF
--- a/bin/good-trip
+++ b/bin/good-trip
@@ -31,6 +31,7 @@ cmd_help() {
   echo ""
   echo -e "${BOLD}Commands:${NC}"
   echo "  configure git [options]               Set up git identity (name, email, GPG key)"
+  echo "  configure p10k [options]              Manage Powerlevel10k config file"
   echo "  update [--yes] [--check] [--silent]   Check and apply updates"
   echo "  update --list                         List available versions"
   echo "  update --version <x.y.z>              Install a specific version"
@@ -52,11 +53,19 @@ cmd_help() {
   echo "  --show             Print current local git config"
   echo "  --reset            Delete local git config"
   echo ""
+  echo -e "${BOLD}Configure options (p10k):${NC}"
+  echo "  --import <file>    Copy <file> to ~/.p10k.zsh (backs up existing)"
+  echo "  --show             Print the current ~/.p10k.zsh header"
+  echo "  --reset            Remove ~/.p10k.zsh"
+  echo ""
   echo -e "${BOLD}Examples:${NC}"
   echo "  good-trip configure git                # Interactive git identity setup"
   echo "  good-trip configure git --show         # Show current git identity config"
   echo "  good-trip configure git --name 'Alice' --email alice@example.com"
   echo "  good-trip configure git --no-sign      # Disable GPG signing"
+  echo "  good-trip configure p10k --import ~/my.p10k.zsh  # Import p10k config"
+  echo "  good-trip configure p10k --show        # Preview current p10k config"
+  echo "  good-trip configure p10k --reset       # Remove ~/.p10k.zsh"
   echo "  good-trip update                       # Interactive update"
   echo "  good-trip update --yes                 # Auto-apply update"
   echo "  good-trip update --check               # Only check, never apply"
@@ -141,17 +150,21 @@ cmd_configure() {
     git)
       bash "${GOOD_TRIP_DIR}/scripts/configure-git.sh" "$@"
       ;;
+    p10k)
+      bash "${GOOD_TRIP_DIR}/scripts/configure-p10k.sh" "$@"
+      ;;
     "")
       error "Usage: good-trip configure <service> [options]"
       echo ""
       echo -e "  Available services:"
       echo -e "    git   — git identity (name, email, GPG signing key)"
+      echo -e "    p10k  — Powerlevel10k config (import, show, reset)"
       echo ""
       exit 1
       ;;
     *)
       error "Unknown service: ${service}"
-      echo "  Available services: git"
+      echo "  Available services: git, p10k"
       exit 1
       ;;
   esac

--- a/scripts/configure-p10k.sh
+++ b/scripts/configure-p10k.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# =============================================================================
+# good-trip — scripts/configure-p10k.sh
+# Import a Powerlevel10k config file (~/.p10k.zsh)
+# =============================================================================
+set -euo pipefail
+
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+RED='\033[0;31m'
+NC='\033[0m'
+log()     { echo -e "${BLUE}[p10k]${NC} $*"; }
+success() { echo -e "${GREEN}[p10k]${NC} ✓ $*"; }
+warn()    { echo -e "${YELLOW}[p10k]${NC} ⚠ $*"; }
+error()   { echo -e "${RED}[p10k]${NC} ✗ $*" >&2; }
+
+P10K_TARGET="$HOME/.p10k.zsh"
+
+usage() {
+  echo ""
+  echo "Usage: good-trip configure p10k --import <file>"
+  echo "       good-trip configure p10k --show"
+  echo "       good-trip configure p10k --reset"
+  echo ""
+  echo "Options:"
+  echo "  --import <file>   Copy <file> to ~/.p10k.zsh"
+  echo "  --show            Print the path and first lines of ~/.p10k.zsh"
+  echo "  --reset           Remove ~/.p10k.zsh (triggers p10k configure on next shell start)"
+  echo ""
+}
+
+cmd_import() {
+  local src="${1:-}"
+  if [[ -z "$src" ]]; then
+    error "--import requires a file path argument."
+    usage
+    exit 1
+  fi
+
+  if [[ ! -f "$src" ]]; then
+    error "File not found: $src"
+    exit 1
+  fi
+
+  # Backup existing config if present
+  if [[ -f "$P10K_TARGET" ]]; then
+    local backup="${P10K_TARGET}.bak.$(date +%Y%m%d%H%M%S)"
+    warn "Backing up existing ~/.p10k.zsh to ${backup}"
+    cp "$P10K_TARGET" "$backup"
+  fi
+
+  cp "$src" "$P10K_TARGET"
+  success "Powerlevel10k config imported from ${src} → ${P10K_TARGET}"
+  log "Reload your shell or run: source ~/.p10k.zsh"
+}
+
+cmd_show() {
+  if [[ ! -f "$P10K_TARGET" ]]; then
+    warn "No ~/.p10k.zsh found. Run 'p10k configure' or 'good-trip configure p10k --import <file>'."
+    exit 0
+  fi
+  log "File: ${P10K_TARGET}"
+  echo ""
+  head -20 "$P10K_TARGET"
+  echo "..."
+}
+
+cmd_reset() {
+  if [[ ! -f "$P10K_TARGET" ]]; then
+    warn "No ~/.p10k.zsh found — nothing to remove."
+    exit 0
+  fi
+  rm -f "$P10K_TARGET"
+  success "Removed ~/.p10k.zsh. Run 'p10k configure' on next shell reload to reconfigure."
+}
+
+# ── Argument parsing ──────────────────────────────────────────────────────────
+if [[ $# -eq 0 ]]; then
+  usage
+  exit 0
+fi
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --import)
+      shift
+      cmd_import "${1:-}"
+      shift || true
+      ;;
+    --show)
+      cmd_show
+      shift
+      ;;
+    --reset)
+      cmd_reset
+      shift
+      ;;
+    --help|-h)
+      usage
+      shift
+      ;;
+    *)
+      error "Unknown option: $1"
+      usage
+      exit 1
+      ;;
+  esac
+done


### PR DESCRIPTION
Add 'good-trip configure p10k' with three options:
- --import <file>: copy a .p10k.zsh file into place, backing up any existing config with a timestamped suffix
- --show: display path and the first 20 lines of ~/.p10k.zsh
- --reset: remove ~/.p10k.zsh so p10k configure runs on next start

Wire the new subcommand into the main CLI dispatcher and update help text and examples accordingly.

Closes #2

## Description

<!-- Describe what this PR does and why -->

## Type of change

- [ ] `feat` — New feature (triggers minor version bump)
- [ ] `fix` — Bug fix (triggers patch version bump)
- [ ] `docs` — Documentation only
- [ ] `refactor` — Code refactoring, no functional change
- [ ] `ci` — CI/CD changes
- [ ] `chore` — Maintenance tasks
- [ ] `BREAKING CHANGE` — Breaking change (triggers major version bump)

## Checklist

- [ ] I followed [Conventional Commits](https://www.conventionalcommits.org/) for all commit messages
- [ ] Shell scripts pass `bash -n` (no syntax errors)
- [ ] Changes are idempotent (safe to run multiple times)
- [ ] Tested on Linux (and macOS if applicable)
- [ ] README updated if needed

## Testing

<!-- Describe how you tested this change -->
