### PR TITLE
feat(bootstrap): add configurable default versions for nvm, sdkman, a…

### DIFF
--- a/bootstrap/install-nvm.sh
+++ b/bootstrap/install-nvm.sh
@@ -13,14 +13,36 @@ success() { echo -e "${GREEN}[nvm]${NC} ✓ $*"; }
 
 NVM_DIR="${NVM_DIR:-$HOME/.nvm}"
 NVM_VERSION="${NVM_VERSION:-v0.40.1}"
+# Set NVM_DEFAULT_NODE to a Node.js version (e.g. "lts/*", "22", "20.11.0")
+# to have that version installed and set as default after NVM is set up.
+NVM_DEFAULT_NODE="${NVM_DEFAULT_NODE:-lts/*}"
 
 if [[ -d "$NVM_DIR" ]] && [[ -s "${NVM_DIR}/nvm.sh" ]]; then
   # shellcheck source=/dev/null
   source "${NVM_DIR}/nvm.sh"
   success "NVM already installed: $(nvm --version)"
+  if [[ -n "$NVM_DEFAULT_NODE" ]]; then
+    log "Ensuring default Node.js version '${NVM_DEFAULT_NODE}' is installed..."
+    nvm install "$NVM_DEFAULT_NODE"
+    nvm alias default "$NVM_DEFAULT_NODE"
+    success "Default Node.js set to: $(nvm version default)"
+  fi
   exit 0
 fi
 
 log "Installing NVM ${NVM_VERSION}..."
 curl -fsSL "https://raw.githubusercontent.com/nvm-sh/nvm/${NVM_VERSION}/install.sh" | bash
-success "NVM installed. Reload your shell to use it."
+success "NVM installed. Reloading NVM..."
+
+# shellcheck source=/dev/null
+export NVM_DIR
+source "${NVM_DIR}/nvm.sh"
+
+if [[ -n "$NVM_DEFAULT_NODE" ]]; then
+  log "Installing default Node.js version '${NVM_DEFAULT_NODE}'..."
+  nvm install "$NVM_DEFAULT_NODE"
+  nvm alias default "$NVM_DEFAULT_NODE"
+  success "Default Node.js set to: $(nvm version default)"
+fi
+
+success "NVM setup complete. Reload your shell to use it."

--- a/bootstrap/install-python.sh
+++ b/bootstrap/install-python.sh
@@ -17,6 +17,11 @@ warn()    { echo -e "${YELLOW}[python]${NC} ⚠ $*"; }
 error()   { echo -e "${RED}[python]${NC} ✗ $*" >&2; }
 has()     { command -v "$1" &>/dev/null; }
 
+# ── Configurable defaults ─────────────────────────────────────────────────────
+# Space-separated list of pip packages to install globally after setup.
+# Override with: PYTHON_GLOBAL_PACKAGES="black isort mypy" ./install.sh
+PYTHON_GLOBAL_PACKAGES="${PYTHON_GLOBAL_PACKAGES:-}"
+
 # ── Detect OS ─────────────────────────────────────────────────────────────────
 detect_os() {
   if [[ "$OSTYPE" == "darwin"* ]]; then
@@ -103,6 +108,25 @@ verify_venv() {
   fi
 }
 
+# ── Install default global packages ──────────────────────────────────────────
+install_global_packages() {
+  if [[ -z "$PYTHON_GLOBAL_PACKAGES" ]]; then
+    return 0
+  fi
+
+  local python_bin
+  python_bin="$(command -v python3 || command -v python)"
+  if [[ -z "$python_bin" ]]; then
+    warn "Python binary not found — skipping global package install."
+    return 0
+  fi
+
+  log "Installing default global packages: ${PYTHON_GLOBAL_PACKAGES}"
+  # shellcheck disable=SC2086
+  "$python_bin" -m pip install --upgrade $PYTHON_GLOBAL_PACKAGES
+  success "Global packages installed."
+}
+
 # ── Summary ───────────────────────────────────────────────────────────────────
 print_versions() {
   echo ""
@@ -121,6 +145,7 @@ main() {
   install_python
   upgrade_pip
   verify_venv
+  install_global_packages
   print_versions
 }
 

--- a/bootstrap/install-sdkman.sh
+++ b/bootstrap/install-sdkman.sh
@@ -13,9 +13,28 @@ success() { echo -e "${GREEN}[sdkman]${NC} ✓ $*"; }
 has()     { command -v "$1" &>/dev/null; }
 
 SDKMAN_DIR="${SDKMAN_DIR:-$HOME/.sdkman}"
+# Set SDKMAN_DEFAULT_JAVA to a Java identifier (e.g. "21.0.3-tem", "17.0.9-tem")
+# to have that version installed and set as default after SDKMAN is set up.
+# Run 'sdk list java' to see available identifiers.
+SDKMAN_DEFAULT_JAVA="${SDKMAN_DEFAULT_JAVA:-}"
+
+# Helper: run sdk commands inside the current shell after sourcing sdkman-init
+_sdk_install_default() {
+  local identifier="${1:-}"
+  if [[ -z "$identifier" ]]; then
+    return 0
+  fi
+  log "Installing default Java SDK '${identifier}'..."
+  # shellcheck source=/dev/null
+  source "${SDKMAN_DIR}/bin/sdkman-init.sh"
+  sdk install java "$identifier" < /dev/null || true
+  sdk default java "$identifier" || true
+  success "Default Java set to: $(sdk current java 2>/dev/null || echo "$identifier")"
+}
 
 if [[ -d "$SDKMAN_DIR" ]] && [[ -s "${SDKMAN_DIR}/bin/sdkman-init.sh" ]]; then
   success "SDKMAN already installed: $("${SDKMAN_DIR}/bin/sdk" version 2>/dev/null || echo "installed")"
+  _sdk_install_default "$SDKMAN_DEFAULT_JAVA"
   exit 0
 fi
 
@@ -26,4 +45,8 @@ fi
 
 log "Installing SDKMAN..."
 curl -fsSL "https://get.sdkman.io" | bash
-success "SDKMAN installed. Reload your shell to use it."
+success "SDKMAN installed."
+
+_sdk_install_default "$SDKMAN_DEFAULT_JAVA"
+
+success "SDKMAN setup complete. Reload your shell to use it."


### PR DESCRIPTION
…nd python

Each installer now respects an environment variable that lets users pre-select a default tool version or package set:

- install-nvm.sh: NVM_DEFAULT_NODE (default: "lts/*") Installs the given Node.js version after NVM setup and sets it as the nvm alias 'default'. Applies on both fresh install and idempotent re-runs.

- install-sdkman.sh: SDKMAN_DEFAULT_JAVA (default: empty, opt-in) When set to a valid SDK identifier (e.g. "21.0.3-tem"), installs and sets that Java version as the SDKMAN default. Applies on both fresh install and idempotent re-runs.

- install-python.sh: PYTHON_GLOBAL_PACKAGES (default: empty, opt-in) Space-separated list of pip packages to install globally after the core Python/pip/venv setup (e.g. "black isort mypy").

Closes #3

## Description

<!-- Describe what this PR does and why -->

## Type of change

- [ ] `feat` — New feature (triggers minor version bump)
- [ ] `fix` — Bug fix (triggers patch version bump)
- [ ] `docs` — Documentation only
- [ ] `refactor` — Code refactoring, no functional change
- [ ] `ci` — CI/CD changes
- [ ] `chore` — Maintenance tasks
- [ ] `BREAKING CHANGE` — Breaking change (triggers major version bump)

## Checklist

- [ ] I followed [Conventional Commits](https://www.conventionalcommits.org/) for all commit messages
- [ ] Shell scripts pass `bash -n` (no syntax errors)
- [ ] Changes are idempotent (safe to run multiple times)
- [ ] Tested on Linux (and macOS if applicable)
- [ ] README updated if needed

## Testing

<!-- Describe how you tested this change -->
