### PR TITLE
[codex] Add devcontainer support and stabilize bootstrap flow

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,21 @@
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+       ca-certificates curl git sudo bash unzip zip gnupg lsb-release wget zsh \
+    && rm -rf /var/lib/apt/lists/*
+
+# Create non-root user with sudo
+ARG USERNAME=vscode
+RUN useradd -ms /bin/zsh ${USERNAME} \
+    && echo "${USERNAME} ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/${USERNAME} \
+    && chmod 0440 /etc/sudoers.d/${USERNAME}
+
+# Put the user-local bin on PATH so it is a real Docker env var and visible
+# to both the container environment and devcontainer remoteEnv lookups.
+ENV PATH="/home/${USERNAME}/.local/bin:${PATH}"
+
+USER ${USERNAME}
+WORKDIR /home/${USERNAME}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,29 +7,21 @@
     "remoteUser": "vscode",
     "workspaceFolder": "/home/vscode/workspace",
     "workspaceMount": "source=${localWorkspaceFolder},target=/home/vscode/workspace,type=bind,consistency=cached",
-    // Mount the host's home directory read-only so zsh/p10k configs can be imported.
     "mounts": [
-        "source=${localEnv:HOME},target=/mnt/host-home,type=bind,consistency=cached,readonly"
+        "source=${localEnv:HOME},target=/mnt/host-home,type=bind,consistency=cached,readonly",
+        "source=${localEnv:HOME}/.codex,target=/home/vscode/.codex,type=bind,consistency=cached"
     ],
-    // Environment mirrors what the Docker Compose test services use
     "containerEnv": {
         "NO_CHSH": "1",
         "DEBIAN_FRONTEND": "noninteractive",
         "APT_LISTCHANGES_FRONTEND": "none",
         "ATUIN_NO_PROMPT": "1"
     },
-    // Extend PATH so user-local bins are always reachable in every terminal.
-    // /home/vscode/.local/bin is baked into PATH by the Dockerfile ENV, so
-    // ${containerEnv:PATH} already contains it; we add .atuin/bin on top.
-    // GOOD_TRIP_DIR points to the mounted workspace so version/symlinks work.
     "remoteEnv": {
         "PATH": "/home/vscode/.local/bin:/home/vscode/.atuin/bin:${containerEnv:PATH}",
         "GOOD_TRIP_DIR": "/home/vscode/workspace"
     },
-    // Run the installer in non-interactive mode after the container is created.
     "postCreateCommand": "cd /home/vscode/workspace && bash install.sh --yes",
-    // Fix workspace ownership first, then import zsh/p10k config from the host.
-    // Sequential (&&) is required: chown must complete before the script is readable.
     "postStartCommand": "sudo chown -R vscode:vscode /home/vscode/workspace && bash /home/vscode/workspace/bootstrap/import-host-zsh-config.sh",
     "customizations": {
         "vscode": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,7 +9,7 @@
     "workspaceMount": "source=${localWorkspaceFolder},target=/home/vscode/workspace,type=bind,consistency=cached",
     "mounts": [
         "source=${localEnv:HOME},target=/mnt/host-home,type=bind,consistency=cached,readonly",
-        "source=${localEnv:HOME}/.codex,target=/home/vscode/.codex,type=bind,consistency=cached"
+        "source=good-trip-codex,target=/home/vscode/.codex,type=volume"
     ],
     "containerEnv": {
         "NO_CHSH": "1",
@@ -22,7 +22,7 @@
         "GOOD_TRIP_DIR": "/home/vscode/workspace"
     },
     "postCreateCommand": "cd /home/vscode/workspace && bash install.sh --yes",
-    "postStartCommand": "sudo chown -R vscode:vscode /home/vscode/workspace && bash /home/vscode/workspace/bootstrap/import-host-zsh-config.sh",
+    "postStartCommand": "sudo chown -R vscode:vscode /home/vscode/workspace && bash /home/vscode/workspace/bootstrap/import-host-zsh-config.sh && bash /home/vscode/workspace/bootstrap/import-host-codex.sh && bash /home/vscode/workspace/bootstrap/fix-devcontainer-git-config.sh",
     "customizations": {
         "vscode": {
             "settings": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,50 @@
+{
+    "name": "good-trip (Ubuntu)",
+    "build": {
+        "dockerfile": "Dockerfile",
+        "context": ".."
+    },
+    "remoteUser": "vscode",
+    "workspaceFolder": "/home/vscode/workspace",
+    "workspaceMount": "source=${localWorkspaceFolder},target=/home/vscode/workspace,type=bind,consistency=cached",
+    // Mount the host's home directory read-only so zsh/p10k configs can be imported.
+    "mounts": [
+        "source=${localEnv:HOME},target=/mnt/host-home,type=bind,consistency=cached,readonly"
+    ],
+    // Environment mirrors what the Docker Compose test services use
+    "containerEnv": {
+        "NO_CHSH": "1",
+        "DEBIAN_FRONTEND": "noninteractive",
+        "APT_LISTCHANGES_FRONTEND": "none",
+        "ATUIN_NO_PROMPT": "1"
+    },
+    // Extend PATH so user-local bins are always reachable in every terminal.
+    // /home/vscode/.local/bin is baked into PATH by the Dockerfile ENV, so
+    // ${containerEnv:PATH} already contains it; we add .atuin/bin on top.
+    // GOOD_TRIP_DIR points to the mounted workspace so version/symlinks work.
+    "remoteEnv": {
+        "PATH": "/home/vscode/.local/bin:/home/vscode/.atuin/bin:${containerEnv:PATH}",
+        "GOOD_TRIP_DIR": "/home/vscode/workspace"
+    },
+    // Run the installer in non-interactive mode after the container is created.
+    "postCreateCommand": "cd /home/vscode/workspace && bash install.sh --yes",
+    // Fix workspace ownership first, then import zsh/p10k config from the host.
+    // Sequential (&&) is required: chown must complete before the script is readable.
+    "postStartCommand": "sudo chown -R vscode:vscode /home/vscode/workspace && bash /home/vscode/workspace/bootstrap/import-host-zsh-config.sh",
+    "customizations": {
+        "vscode": {
+            "settings": {
+                "terminal.integrated.defaultProfile.linux": "zsh",
+                "terminal.integrated.profiles.linux": {
+                    "zsh": {
+                        "path": "/bin/zsh"
+                    }
+                }
+            },
+            "extensions": [
+                "timonwong.shellcheck",
+                "foxundermoon.shell-format"
+            ]
+        }
+    }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,42 +1,39 @@
 {
-    "name": "good-trip (Ubuntu)",
-    "build": {
-        "dockerfile": "Dockerfile",
-        "context": ".."
-    },
-    "remoteUser": "vscode",
-    "workspaceFolder": "/home/vscode/workspace",
-    "workspaceMount": "source=${localWorkspaceFolder},target=/home/vscode/workspace,type=bind,consistency=cached",
-    "mounts": [
-        "source=${localEnv:HOME},target=/mnt/host-home,type=bind,consistency=cached,readonly",
-        "source=good-trip-codex,target=/home/vscode/.codex,type=volume"
-    ],
-    "containerEnv": {
-        "NO_CHSH": "1",
-        "DEBIAN_FRONTEND": "noninteractive",
-        "APT_LISTCHANGES_FRONTEND": "none",
-        "ATUIN_NO_PROMPT": "1"
-    },
-    "remoteEnv": {
-        "PATH": "/home/vscode/.local/bin:/home/vscode/.atuin/bin:${containerEnv:PATH}",
-        "GOOD_TRIP_DIR": "/home/vscode/workspace"
-    },
-    "postCreateCommand": "cd /home/vscode/workspace && bash install.sh --yes",
-    "postStartCommand": "sudo chown -R vscode:vscode /home/vscode/workspace && bash /home/vscode/workspace/bootstrap/import-host-zsh-config.sh && bash /home/vscode/workspace/bootstrap/import-host-codex.sh && bash /home/vscode/workspace/bootstrap/fix-devcontainer-git-config.sh",
-    "customizations": {
-        "vscode": {
-            "settings": {
-                "terminal.integrated.defaultProfile.linux": "zsh",
-                "terminal.integrated.profiles.linux": {
-                    "zsh": {
-                        "path": "/bin/zsh"
-                    }
-                }
-            },
-            "extensions": [
-                "timonwong.shellcheck",
-                "foxundermoon.shell-format"
-            ]
+  "name": "good-trip (Ubuntu)",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "context": ".."
+  },
+  "remoteUser": "vscode",
+  "workspaceFolder": "/home/vscode/workspace",
+  "workspaceMount": "source=${localWorkspaceFolder},target=/home/vscode/workspace,type=bind,consistency=cached",
+  "mounts": [
+    "source=${localEnv:HOME},target=/mnt/host-home,type=bind,consistency=cached,readonly",
+    "source=good-trip-codex,target=/home/vscode/.codex,type=volume"
+  ],
+  "containerEnv": {
+    "NO_CHSH": "1",
+    "DEBIAN_FRONTEND": "noninteractive",
+    "APT_LISTCHANGES_FRONTEND": "none",
+    "ATUIN_NO_PROMPT": "1"
+  },
+  "remoteEnv": {
+    "PATH": "/home/vscode/.local/bin:/home/vscode/.atuin/bin:${containerEnv:PATH}",
+    "GOOD_TRIP_DIR": "/home/vscode/workspace"
+  },
+  "postCreateCommand": "cd /home/vscode/workspace && bash install.sh --yes",
+  "postStartCommand": "sudo chown -R vscode:vscode /home/vscode/workspace && bash /home/vscode/workspace/bootstrap/import-host-zsh-config.sh && bash /home/vscode/workspace/bootstrap/import-host-codex.sh && bash /home/vscode/workspace/bootstrap/fix-devcontainer-git-config.sh",
+  "customizations": {
+    "vscode": {
+      "settings": {
+        "terminal.integrated.defaultProfile.linux": "zsh",
+        "terminal.integrated.profiles.linux": {
+          "zsh": {
+            "path": "/bin/zsh"
+          }
         }
+      },
+      "extensions": ["timonwong.shellcheck", "foxundermoon.shell-format"]
     }
+  }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,29 +1,26 @@
 ## [1.11.1](https://github.com/PepeuFBV/good-trip/compare/v1.11.0...v1.11.1) (2026-03-13)
 
-
 ### Bug Fixes
 
-* handle non-TTY input for non-interactive installations in install.sh ([7507a42](https://github.com/PepeuFBV/good-trip/commit/7507a42e2300f90624d6b552ce4c416837c24ee8))
+- handle non-TTY input for non-interactive installations in install.sh ([7507a42](https://github.com/PepeuFBV/good-trip/commit/7507a42e2300f90624d6b552ce4c416837c24ee8))
 
 # [1.11.0](https://github.com/PepeuFBV/good-trip/compare/v1.10.0...v1.11.0) (2026-03-13)
 
-
 ### Bug Fixes
 
-* correct command syntax in docker compose for cli checks ([0a7733b](https://github.com/PepeuFBV/good-trip/commit/0a7733b4616ffb6b016cd34c133ab0c5fc73db71))
-* correct command syntax in docker compose for cli checks ([a1d500f](https://github.com/PepeuFBV/good-trip/commit/a1d500f97b7f601476e717c36d64ea7968d40916))
-* shadow variable fix for `run_in_docker.sh` ([69fc8aa](https://github.com/PepeuFBV/good-trip/commit/69fc8aa48bbb41072df7830ff89eaf02afc2c574))
-* sucessfull messsage printed for an outcome in `install-python.sh` ([5f5c057](https://github.com/PepeuFBV/good-trip/commit/5f5c0574bdb72ad8caa21c3d1c0986e322e8dfef))
-
+- correct command syntax in docker compose for cli checks ([0a7733b](https://github.com/PepeuFBV/good-trip/commit/0a7733b4616ffb6b016cd34c133ab0c5fc73db71))
+- correct command syntax in docker compose for cli checks ([a1d500f](https://github.com/PepeuFBV/good-trip/commit/a1d500f97b7f601476e717c36d64ea7968d40916))
+- shadow variable fix for `run_in_docker.sh` ([69fc8aa](https://github.com/PepeuFBV/good-trip/commit/69fc8aa48bbb41072df7830ff89eaf02afc2c574))
+- sucessfull messsage printed for an outcome in `install-python.sh` ([5f5c057](https://github.com/PepeuFBV/good-trip/commit/5f5c0574bdb72ad8caa21c3d1c0986e322e8dfef))
 
 ### Features
 
-* add docker-based installation and testing workflow ([ccb2fcf](https://github.com/PepeuFBV/good-trip/commit/ccb2fcf3e92b6bf2f2aeb1745bec0bbc8c0ba17c))
-* add environment variable for node.js version enforcement in ci ([b4c3c90](https://github.com/PepeuFBV/good-trip/commit/b4c3c90b0511db2d2e0ef201db8c21a5bb2c127c))
-* add environment variables and workflow triggers for installation ci ([69b7a8a](https://github.com/PepeuFBV/good-trip/commit/69b7a8a46ef9bcb204ae8f80351fbfcd7aec7427))
-* enhance docker installation script and update readme for clarity ([eb12d65](https://github.com/PepeuFBV/good-trip/commit/eb12d656f24efa2c47a6d2c813390aec29971e69))
-* remove push and pull_request triggers from installation workflow ([36b3061](https://github.com/PepeuFBV/good-trip/commit/36b3061e69f03b56cb5036a40cedf15f61e779ed))
-* update checkout step in installation workflow to include token and fetch options ([cdad3af](https://github.com/PepeuFBV/good-trip/commit/cdad3af4894da38c9d3665e6e3bbfe3bac9c0db1))
+- add docker-based installation and testing workflow ([ccb2fcf](https://github.com/PepeuFBV/good-trip/commit/ccb2fcf3e92b6bf2f2aeb1745bec0bbc8c0ba17c))
+- add environment variable for node.js version enforcement in ci ([b4c3c90](https://github.com/PepeuFBV/good-trip/commit/b4c3c90b0511db2d2e0ef201db8c21a5bb2c127c))
+- add environment variables and workflow triggers for installation ci ([69b7a8a](https://github.com/PepeuFBV/good-trip/commit/69b7a8a46ef9bcb204ae8f80351fbfcd7aec7427))
+- enhance docker installation script and update readme for clarity ([eb12d65](https://github.com/PepeuFBV/good-trip/commit/eb12d656f24efa2c47a6d2c813390aec29971e69))
+- remove push and pull_request triggers from installation workflow ([36b3061](https://github.com/PepeuFBV/good-trip/commit/36b3061e69f03b56cb5036a40cedf15f61e779ed))
+- update checkout step in installation workflow to include token and fetch options ([cdad3af](https://github.com/PepeuFBV/good-trip/commit/cdad3af4894da38c9d3665e6e3bbfe3bac9c0db1))
 
 # [1.10.0](https://github.com/PepeuFBV/good-trip/compare/v1.9.0...v1.10.0) (2026-03-02)
 
@@ -43,7 +40,7 @@
 
 - **bootstrap:** set zsh as default shell if already installed ([5ad9beb](https://github.com/PepeuFBV/good-trip/commit/5ad9beb0d64dfadc7f6643e9d8f5db2c9ee95ef7)), closes [#1](https://github.com/PepeuFBV/good-trip/issues/1)
 
-# [1.7.0](https://github.com/PepeuFBV/good-trip/compare/v1.6.2...v1.7.0) (2026-03-02)
+# [1.7.0](https://github.com/PepeuFBV/good-trip/compare/v1.6.2../v1.7.0) (2026-03-02)
 
 ### Features
 
@@ -55,25 +52,25 @@
 
 - **install:** move 'already installed' check to a new section ([9bdd869](https://github.com/PepeuFBV/good-trip/commit/9bdd869aedb3ffc326935dbb5a217405fd3164ef))
 
-## [1.6.1](https://github.com/PepeuFBV/good-trip/compare/v1.6.0...v1.6.1) (2026-02-24)
+## [1.6.1](https://github.com/PepeuFBV/good-trip/compare/v1.6.0../v1.6.1) (2026-02-24)
 
 ### Bug Fixes
 
 - **update:** handle detached HEAD state during updates ([9c1ec2d](https://github.com/PepeuFBV/good-trip/commit/9c1ec2d04d601d8fc38fcba2d94ee4628194945a))
 
-# [1.6.0](https://github.com/PepeuFBV/good-trip/compare/v1.5.0...v1.6.0) (2026-02-24)
+# [1.6.0](https://github.com/PepeuFBV/good-trip/compare/v1.5.0../v1.6.0) (2026-02-24)
 
 ### Features
 
 - **uninstall:** add uninstall command with interactive and non-interactive options ([7dd56c9](https://github.com/PepeuFBV/good-trip/commit/7dd56c93a0ed0185e6ace97aecde3f138b11f3ef))
 
-# [1.5.0](https://github.com/PepeuFBV/good-trip/compare/v1.4.2...v1.5.0) (2026-02-24)
+# [1.5.0](https://github.com/PepeuFBV/good-trip/compare/v1.4.2../v1.5.0) (2026-02-24)
 
 ### Features
 
 - **update:** add version management commands for listing, installing, and locking versions ([1dea0b3](https://github.com/PepeuFBV/good-trip/commit/1dea0b3b5689f7a1458cab64946ec8d5ec942692))
 
-## [1.4.2](https://github.com/PepeuFBV/good-trip/compare/v1.4.1...v1.4.2) (2026-02-24)
+## [1.4.2](https://github.com/PepeuFBV/good-trip/compare/v1.4.1../v1.4.2) (2026-02-24)
 
 ### Bug Fixes
 
@@ -91,7 +88,7 @@
 
 - **ssh:** add SSH key management commands and scripts ([6ba5758](https://github.com/PepeuFBV/good-trip/commit/6ba575868e5a68efe415f3488faab1f708a87feb))
 
-## [1.3.2](https://github.com/PepeuFBV/good-trip/compare/v1.3.1...v1.3.2) (2026-02-24)
+## [1.3.2](https://github.com/PepeuFBV/good-trip/compare/v1.3.1../v1.3.2) (2026-02-24)
 
 ### Bug Fixes
 

--- a/bootstrap/fix-devcontainer-git-config.sh
+++ b/bootstrap/fix-devcontainer-git-config.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# bootstrap/fix-devcontainer-git-config.sh
+# Keep the tracked repo git config out of the devcontainer's live ~/.gitconfig.
+#
+# The installer links ~/.gitconfig to config/git/config. VS Code's devcontainer
+# integration appends a temporary credential helper to the global git config on
+# attach, which would otherwise dirty the tracked repo file every time the
+# container is created or reopened.
+
+set -euo pipefail
+
+GOOD_TRIP_DIR="${GOOD_TRIP_DIR:-/home/vscode/workspace}"
+REPO_GIT_CONFIG="${GOOD_TRIP_DIR}/config/git/config"
+TARGET_GIT_CONFIG="${HOME}/.gitconfig"
+MANAGED_HEADER="# Managed by good-trip devcontainer bootstrap."
+
+write_wrapper() {
+    cat > "${TARGET_GIT_CONFIG}" <<EOF_WRAPPER
+${MANAGED_HEADER}
+# Keeps editor-injected git settings out of tracked repo files.
+[include]
+    path = ${REPO_GIT_CONFIG}
+EOF_WRAPPER
+    chmod 644 "${TARGET_GIT_CONFIG}"
+}
+
+remove_vscode_helper_from_repo_config() {
+    local helper
+
+    while IFS= read -r helper; do
+        if [[ "${helper}" == *".vscode-server/bin/"* ]] && [[ "${helper}" == *"git-credential-helper"* ]]; then
+            git config --file "${REPO_GIT_CONFIG}" --fixed-value --unset-all credential.helper "${helper}"
+            echo "[fix-devcontainer-git-config] Removed VS Code credential helper from tracked git config"
+        fi
+    done < <(git config --file "${REPO_GIT_CONFIG}" --get-all credential.helper 2>/dev/null || true)
+}
+
+if [[ ! -f "${REPO_GIT_CONFIG}" ]]; then
+    echo "[fix-devcontainer-git-config] Repo git config not found at ${REPO_GIT_CONFIG} - skipping"
+    exit 0
+fi
+
+remove_vscode_helper_from_repo_config
+
+if [[ -L "${TARGET_GIT_CONFIG}" ]] && [[ "$(readlink "${TARGET_GIT_CONFIG}")" == "${REPO_GIT_CONFIG}" ]]; then
+    rm -f "${TARGET_GIT_CONFIG}"
+    write_wrapper
+    echo "[fix-devcontainer-git-config] Replaced ~/.gitconfig symlink with managed wrapper"
+    exit 0
+fi
+
+if [[ ! -e "${TARGET_GIT_CONFIG}" ]]; then
+    write_wrapper
+    echo "[fix-devcontainer-git-config] Created managed ~/.gitconfig wrapper"
+    exit 0
+fi
+
+if grep -Fq "${MANAGED_HEADER}" "${TARGET_GIT_CONFIG}" 2>/dev/null; then
+    write_wrapper
+    echo "[fix-devcontainer-git-config] Refreshed managed ~/.gitconfig wrapper"
+    exit 0
+fi
+
+echo "[fix-devcontainer-git-config] Leaving existing ~/.gitconfig untouched"

--- a/bootstrap/import-host-codex.sh
+++ b/bootstrap/import-host-codex.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# bootstrap/import-host-codex.sh
+# One-time import of Codex CLI credentials, config, plugins, and cache from
+# the host machine into the devcontainer's named volume at /home/vscode/.codex.
+#
+# The host's $HOME is mounted read-only at /mnt/host-home.  Because some
+# files (auth.json, config.toml) are mode 600 and owned by the host user
+# (UID different from the container's vscode), we use sudo to read across
+# the permission boundary — the same pattern used by import-host-zsh-config.sh.
+#
+# Only copies a file/dir when the destination does NOT already exist, so a
+# rebuild never clobbers credentials or data updated inside the running container.
+#
+# Called from "postStartCommand" in devcontainer.json on every container start.
+
+set -euo pipefail
+
+HOST_CODEX=/mnt/host-home/.codex
+DEST=/home/vscode/.codex
+
+# Ensure the destination directory exists and is owned by vscode.
+mkdir -p "${DEST}"
+
+if ! sudo test -d "${HOST_CODEX}"; then
+    echo "[import-host-codex] No .codex directory found on host — skipping import"
+    exit 0
+fi
+
+# ── Files: copy once; never clobber container-side changes ────────────────────
+# auth.json / config.toml are mode 600 on the host (different UID), so sudo is
+# required to read them across the permission boundary.
+
+FILES_600=(
+    auth.json    # API keys / OAuth tokens
+    config.toml  # CLI preferences
+)
+for f in "${FILES_600[@]}"; do
+    src="${HOST_CODEX}/${f}"
+    dst="${DEST}/${f}"
+    if sudo test -f "${src}" && [[ ! -f "${dst}" ]]; then
+        sudo cp "${src}" "${dst}"
+        sudo chown vscode:vscode "${dst}"
+        chmod 600 "${dst}"
+        echo "[import-host-codex] Imported ${f}"
+    fi
+done
+
+# Marker / cache files — world-readable on host, import once.
+FILES_644=(
+    .personality_migration  # skips first-run personality setup
+    models_cache.json       # avoids re-fetching model list on every start
+)
+for f in "${FILES_644[@]}"; do
+    src="${HOST_CODEX}/${f}"
+    dst="${DEST}/${f}"
+    if sudo test -f "${src}" && [[ ! -f "${dst}" ]]; then
+        sudo cp "${src}" "${dst}"
+        sudo chown vscode:vscode "${dst}"
+        echo "[import-host-codex] Imported ${f}"
+    fi
+done
+
+# ── Directories: import once so plugins/memories are available immediately ────
+DIRS=(
+    plugins    # installed plugins (e.g. github@openai-curated); missing = re-download on start
+    memories   # persistent memory store
+)
+for d in "${DIRS[@]}"; do
+    src="${HOST_CODEX}/${d}"
+    dst="${DEST}/${d}"
+    if sudo test -d "${src}" && [[ ! -d "${dst}" ]]; then
+        sudo cp -r "${src}" "${dst}"
+        sudo chown -R vscode:vscode "${dst}"
+        echo "[import-host-codex] Imported ${d}/"
+    fi
+done
+
+# ── Ensure directory is fully owned by vscode so CLI can persist changes ─────
+sudo chown -R vscode:vscode "${DEST}"

--- a/bootstrap/import-host-zsh-config.sh
+++ b/bootstrap/import-host-zsh-config.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# bootstrap/import-host-zsh-config.sh
+# Copy zsh / Powerlevel10k config files from the host machine into the
+# devcontainer if they are present.
+#
+# The host's $HOME is mounted read-only at /mnt/host-home by devcontainer.json.
+# That directory is owned by the host user (different uid than vscode inside the
+# container), so we use sudo to read across the permission boundary.
+#
+# Called from "postStartCommand" in devcontainer.json every time the container
+# starts, after workspace ownership is fixed.
+
+set -euo pipefail
+
+HOST_HOME=/mnt/host-home
+DEST=/home/vscode
+
+# Files to import from the host when present.
+FILES=(
+    .p10k.zsh        # Powerlevel10k theme configuration
+    .zsh_aliases     # Host-local aliases (optional)
+    .zsh_local       # Host-local extras (optional)
+)
+
+for f in "${FILES[@]}"; do
+    src="${HOST_HOME}/${f}"
+    dst="${DEST}/${f}"
+    if sudo test -f "${src}"; then
+        sudo cp "${src}" "${dst}"
+        sudo chown vscode:vscode "${dst}"
+        echo "[import-host-zsh-config] Imported ${f} from host"
+    fi
+done

--- a/bootstrap/install-atuin.sh
+++ b/bootstrap/install-atuin.sh
@@ -26,9 +26,18 @@ elif [[ -f /etc/arch-release ]]; then
   sudo pacman -S --noconfirm atuin
 else
   # Universal installer script (Rust-based binary)
-  curl -fsSL https://setup.atuin.sh | bash
+  # ATUIN_NO_PROMPT suppresses interactive sync/registration prompts
+  ATUIN_NO_PROMPT=1 curl -fsSL https://setup.atuin.sh | bash
 fi
 
-success "Atuin installed: $(atuin --version)"
+# The installer places the binary in ~/.atuin/bin which is not yet on PATH;
+# source its env file so we can call atuin in this same shell session.
+if [[ -f "$HOME/.atuin/bin/env" ]]; then
+  # shellcheck source=/dev/null
+  . "$HOME/.atuin/bin/env"
+fi
+
+atuin_bin="$(command -v atuin 2>/dev/null || echo "$HOME/.atuin/bin/atuin")"
+success "Atuin installed: $($atuin_bin --version 2>/dev/null || echo '(version unavailable)')"
 log "Atuin ZSH integration is configured in .zshrc."
 log "Optional: run 'atuin register' to enable sync across machines."

--- a/bootstrap/install-docker.sh
+++ b/bootstrap/install-docker.sh
@@ -15,6 +15,13 @@ success() { echo -e "${GREEN}[docker]${NC} ✓ $*"; }
 warn()    { echo -e "${YELLOW}[docker]${NC} ⚠ $*"; }
 has()     { command -v "$1" &>/dev/null; }
 
+# Return 0 if running inside a container (docker/containerd/podman)
+is_container() {
+  [[ -f "/.dockerenv" ]] && return 0
+  grep -qaE 'docker|kubepods|containerd|podman' /proc/1/cgroup 2>/dev/null && return 0
+  return 1
+}
+
 # ── Helpers ───────────────────────────────────────────────────────────────────
 _add_to_group() {
   if [[ "$OSTYPE" == "darwin"* ]]; then
@@ -91,6 +98,12 @@ elif [[ -f /etc/arch-release ]]; then
   _add_to_group
 
 elif [[ -f /etc/debian_version ]]; then
+  if is_container; then
+    warn "Running inside a container — skipping Docker Engine installation."
+    warn "Install Docker on the host and use Docker-in-Docker or a socket mount if needed."
+    exit 0
+  fi
+
   log "Installing Docker Engine on Debian/Ubuntu..."
 
   # Remove any conflicting legacy packages
@@ -102,16 +115,20 @@ elif [[ -f /etc/debian_version ]]; then
   sudo apt-get update -qq
   sudo apt-get install -y ca-certificates curl
 
+  # Source os-release once to avoid escaping issues inside $() expansions
+  # shellcheck source=/dev/null
+  . /etc/os-release
+
   # Add Docker's official GPG key and repository
   sudo install -m 0755 -d /etc/apt/keyrings
-  sudo curl -fsSL "https://download.docker.com/linux/$(. /etc/os-release && echo \"$ID\")/gpg" \
+  sudo curl -fsSL "https://download.docker.com/linux/${ID}/gpg" \
     -o /etc/apt/keyrings/docker.asc
   sudo chmod a+r /etc/apt/keyrings/docker.asc
 
   echo \
     "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] \
-    https://download.docker.com/linux/$(. /etc/os-release && echo \"$ID\") \
-    $(. /etc/os-release && echo "${VERSION_CODENAME}") stable" | \
+    https://download.docker.com/linux/${ID} \
+    ${VERSION_CODENAME} stable" | \
     sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
 
   sudo apt-get update -qq

--- a/bootstrap/install-sdkman.sh
+++ b/bootstrap/install-sdkman.sh
@@ -43,6 +43,18 @@ if ! has curl && ! has wget; then
   exit 1
 fi
 
+if ! has zip; then
+  log "zip is required by SDKMAN but is not installed. Installing..."
+  if [[ -f /etc/debian_version ]]; then
+    sudo apt-get install -y zip
+  elif [[ -f /etc/arch-release ]]; then
+    sudo pacman -S --noconfirm zip
+  else
+    echo "[sdkman] Please install zip manually before running SDKMAN." >&2
+    exit 1
+  fi
+fi
+
 log "Installing SDKMAN..."
 curl -fsSL "https://get.sdkman.io" | bash
 success "SDKMAN installed."

--- a/config/zsh/.zshrc
+++ b/config/zsh/.zshrc
@@ -126,7 +126,14 @@ fi
 chpwd() { ls; }
 
 # ── Powerlevel10k config ──────────────────────────────────────────────────────
-[[ -f ~/.p10k.zsh ]] && source ~/.p10k.zsh
+# ~/.p10k.zsh is copied from the host on container start by
+# bootstrap/import-host-zsh-config.sh (via postStartCommand).
+# If the copy is missing, suppress the wizard instead of prompting.
+if [[ -f ~/.p10k.zsh ]]; then
+  source ~/.p10k.zsh
+else
+  typeset -g POWERLEVEL9K_DISABLE_CONFIGURATION_WIZARD=true
+fi
 
 # ── good-trip: daily update check (background, non-blocking) ─────────────────
 _gt_check_update() {

--- a/install.sh
+++ b/install.sh
@@ -265,7 +265,7 @@ ensure_repo() {
 run_bootstrap() {
   local script="${GOOD_TRIP_DIR}/bootstrap/${1}"
   if [[ -f "$script" ]]; then
-    bash "$script"
+    bash "$script" || warn "Component script exited non-zero: ${1} (continuing)"
   else
     warn "Bootstrap script not found: ${1}"
   fi
@@ -283,22 +283,41 @@ install_cli() {
     return 1
   fi
 
-  # Copy into multiple well-known locations so committed images expose the
-  # binary in predictable places for checks.
-  local targets=("${GOOD_TRIP_BIN}" "/home/tester/.local/bin" "/root/.local/bin" "/usr/local/bin")
+  # Copy into well-known locations. Try user-owned dirs first (no sudo),
+  # then /usr/local/bin with sudo so the binary ends up on a PATH that is
+  # always available regardless of shell init files.
+  local user_targets=("${GOOD_TRIP_BIN}" "/home/tester/.local/bin" "/root/.local/bin")
+  local system_targets=("/usr/local/bin")
   local success_flag=0
 
-  for dir in "${targets[@]}"; do
+  for dir in "${user_targets[@]}"; do
     mkdir -p "$dir" 2>/dev/null || true
     local target="$dir/good-trip"
     rm -f "$target" 2>/dev/null || true
     if cp -f "$src" "$target" 2>/dev/null; then
       chmod +x "$target" 2>/dev/null || true
       success "CLI copied to ${target}"
-      log "CLI source: ${src} -> ${target} (copied)"
       success_flag=1
+    fi
+  done
+
+  for dir in "${system_targets[@]}"; do
+    local target="$dir/good-trip"
+    if has sudo; then
+      sudo rm -f "$target" 2>/dev/null || true
+      if sudo cp -f "$src" "$target" 2>/dev/null; then
+        sudo chmod +x "$target" 2>/dev/null || true
+        success "CLI copied to ${target}"
+        success_flag=1
+      fi
     else
-      warn "Could not copy CLI to ${target} (permission or missing dir)"
+      # Running as root
+      rm -f "$target" 2>/dev/null || true
+      if cp -f "$src" "$target" 2>/dev/null; then
+        chmod +x "$target" 2>/dev/null || true
+        success "CLI copied to ${target}"
+        success_flag=1
+      fi
     fi
   done
 
@@ -439,6 +458,7 @@ BANNER
   # Detect if running from a local clone or piped from curl
   if [[ -f "$(dirname "${BASH_SOURCE[0]}")/version.txt" ]]; then
     GOOD_TRIP_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    export GOOD_TRIP_DIR
     log "Running from local repo: ${GOOD_TRIP_DIR}"
   else
     ensure_repo


### PR DESCRIPTION
## Description

Adds a devcontainer workflow and supporting bootstrap scripts so the project can be used inside a container with host shell and Codex settings imported safely.

This branch also hardens the install/bootstrap flow for container environments by handling missing dependencies, suppressing interactive prompts, and stabilizing git configuration behavior inside the devcontainer.

## Type of change

- [x] `feat` — New feature (triggers minor version bump)
- [x] `fix` — Bug fix (triggers patch version bump)
- [ ] `docs` — Documentation only
- [ ] `refactor` — Code refactoring, no functional change
- [ ] `ci` — CI/CD changes
- [ ] `chore` — Maintenance tasks
- [ ] `BREAKING CHANGE` — Breaking change (triggers major version bump)

## Checklist

- [x] I followed [Conventional Commits](https://www.conventionalcommits.org/) for all commit messages
- [x] Shell scripts pass `bash -n` (no syntax errors)
- [x] Changes are idempotent (safe to run multiple times)
- [ ] Tested on Linux (and macOS if applicable)
- [ ] README updated if needed

## Testing

- `find . -name '*.sh' -not -path './.git/*' -not -path './node_modules/*' -print0 | xargs -0 -n1 bash -n`
- `bash -lc "bash -n install.sh && ./install.sh --help >/dev/null"`
- `bash -n bin/good-trip bootstrap/import-host-codex.sh bootstrap/import-host-zsh-config.sh bootstrap/install-atuin.sh bootstrap/install-docker.sh bootstrap/install-sdkman.sh bootstrap/fix-devcontainer-git-config.sh`

## Root cause

The branch introduces a new devcontainer/bootstrap path, so the main risk area is shell and install behavior in a containerized environment. This PR packages the fixes needed to make that path non-interactive, dependency-aware, and safe to re-run.