### PR TITLE
Refactor/shared-shell-helpers merge

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -22,7 +22,7 @@
     "GOOD_TRIP_DIR": "/home/vscode/workspace"
   },
   "postCreateCommand": "cd /home/vscode/workspace && bash install.sh --yes",
-  "postStartCommand": "sudo chown -R vscode:vscode /home/vscode/workspace && bash /home/vscode/workspace/bootstrap/import-host-zsh-config.sh && bash /home/vscode/workspace/bootstrap/import-host-codex.sh && bash /home/vscode/workspace/bootstrap/fix-devcontainer-git-config.sh",
+  "postStartCommand": "sudo chown -R vscode:vscode /home/vscode/workspace && bash /home/vscode/workspace/.devcontainer/scripts/import-host-zsh-config.sh && bash /home/vscode/workspace/.devcontainer/scripts/import-host-codex.sh && bash /home/vscode/workspace/.devcontainer/scripts/fix-devcontainer-git-config.sh",
   "customizations": {
     "vscode": {
       "settings": {

--- a/.devcontainer/scripts/fix-devcontainer-git-config.sh
+++ b/.devcontainer/scripts/fix-devcontainer-git-config.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# bootstrap/fix-devcontainer-git-config.sh
+# .devcontainer/scripts/fix-devcontainer-git-config.sh
 # Keep the tracked repo git config out of the devcontainer's live ~/.gitconfig.
 #
 # The installer links ~/.gitconfig to config/git/config. VS Code's devcontainer

--- a/.devcontainer/scripts/import-host-codex.sh
+++ b/.devcontainer/scripts/import-host-codex.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# bootstrap/import-host-codex.sh
+# .devcontainer/scripts/import-host-codex.sh
 # One-time import of Codex CLI credentials, config, plugins, and cache from
 # the host machine into the devcontainer's named volume at /home/vscode/.codex.
 #

--- a/.devcontainer/scripts/import-host-zsh-config.sh
+++ b/.devcontainer/scripts/import-host-zsh-config.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# bootstrap/import-host-zsh-config.sh
+# .devcontainer/scripts/import-host-zsh-config.sh
 # Copy zsh / Powerlevel10k config files from the host machine into the
 # devcontainer if they are present.
 #

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,21 +1,19 @@
 # [1.12.0](https://github.com/PepeuFBV/good-trip/compare/v1.11.1...v1.12.0) (2026-04-12)
 
-
 ### Bug Fixes
 
-* auto-install missing zip dependency for sdkman ([246544a](https://github.com/PepeuFBV/good-trip/commit/246544a2dc01ffc3443d7f31e89a4982cd9a57e5))
-* format files for prettier ([cac033d](https://github.com/PepeuFBV/good-trip/commit/cac033d4e55a89fed821e3cc7a119604e27a9da1))
-* skip docker engine install when running inside a container ([f3e2552](https://github.com/PepeuFBV/good-trip/commit/f3e25528f6ed3d7420a1d292d8d2d8856fb71d0d))
-* stabilize devcontainer git config ([fe6f733](https://github.com/PepeuFBV/good-trip/commit/fe6f733b55d709fa8e65fd224b0455a51b69db8b))
-* suppress interactive prompts and source path in atuin installer ([f45b03b](https://github.com/PepeuFBV/good-trip/commit/f45b03bd1a8af065e8fa8263bec2ddec826c16c9))
-* update devcontainer configuration to include .codex directory mount ([9f1da51](https://github.com/PepeuFBV/good-trip/commit/9f1da51fbfc7f600308a1ac20516117d79f88ba4))
-* use sudo fallback for cli install and export good_trip_dir ([77345cc](https://github.com/PepeuFBV/good-trip/commit/77345cc33898b7eaf988368dfb8f65f64157e642))
-
+- auto-install missing zip dependency for sdkman ([246544a](https://github.com/PepeuFBV/good-trip/commit/246544a2dc01ffc3443d7f31e89a4982cd9a57e5))
+- format files for prettier ([cac033d](https://github.com/PepeuFBV/good-trip/commit/cac033d4e55a89fed821e3cc7a119604e27a9da1))
+- skip docker engine install when running inside a container ([f3e2552](https://github.com/PepeuFBV/good-trip/commit/f3e25528f6ed3d7420a1d292d8d2d8856fb71d0d))
+- stabilize devcontainer git config ([fe6f733](https://github.com/PepeuFBV/good-trip/commit/fe6f733b55d709fa8e65fd224b0455a51b69db8b))
+- suppress interactive prompts and source path in atuin installer ([f45b03b](https://github.com/PepeuFBV/good-trip/commit/f45b03bd1a8af065e8fa8263bec2ddec826c16c9))
+- update devcontainer configuration to include .codex directory mount ([9f1da51](https://github.com/PepeuFBV/good-trip/commit/9f1da51fbfc7f600308a1ac20516117d79f88ba4))
+- use sudo fallback for cli install and export good_trip_dir ([77345cc](https://github.com/PepeuFBV/good-trip/commit/77345cc33898b7eaf988368dfb8f65f64157e642))
 
 ### Features
 
-* add devcontainer configuration ([9c8c3be](https://github.com/PepeuFBV/good-trip/commit/9c8c3beecc0f3a5ba00280121f6e7791cf2ae4e0))
-* import host zsh and p10k config in devcontainer ([27f5c35](https://github.com/PepeuFBV/good-trip/commit/27f5c35f533d4d7cf3b6e921d73e3b3f67da4edc))
+- add devcontainer configuration ([9c8c3be](https://github.com/PepeuFBV/good-trip/commit/9c8c3beecc0f3a5ba00280121f6e7791cf2ae4e0))
+- import host zsh and p10k config in devcontainer ([27f5c35](https://github.com/PepeuFBV/good-trip/commit/27f5c35f533d4d7cf3b6e921d73e3b3f67da4edc))
 
 ## [1.11.1](https://github.com/PepeuFBV/good-trip/compare/v1.11.0...v1.11.1) (2026-03-13)
 

--- a/bin/good-trip
+++ b/bin/good-trip
@@ -6,18 +6,42 @@
 set -euo pipefail
 
 GOOD_TRIP_DIR="${GOOD_TRIP_DIR:-$HOME/.good-trip}"
+CLI_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-BLUE='\033[0;34m'
-BOLD='\033[1m'
-NC='\033[0m'
+bootstrap_common() {
+  RED='\033[0;31m'
+  GREEN='\033[0;32m'
+  YELLOW='\033[1;33m'
+  BLUE='\033[0;34m'
+  BOLD='\033[1m'
+  NC='\033[0m'
 
-log()     { echo -e "${BLUE}[good-trip]${NC} $*"; }
-success() { echo -e "${GREEN}[good-trip]${NC} ✓ $*"; }
-warn()    { echo -e "${YELLOW}[good-trip]${NC} ⚠ $*"; }
-error()   { echo -e "${RED}[good-trip]${NC} ✗ $*" >&2; }
+  log()     { echo -e "${BLUE}[good-trip]${NC} $*"; }
+  success() { echo -e "${GREEN}[good-trip]${NC} ✓ $*"; }
+  warn()    { echo -e "${YELLOW}[good-trip]${NC} ⚠ $*"; }
+  error()   { echo -e "${RED}[good-trip]${NC} ✗ $*" >&2; }
+}
+
+load_common() {
+  local common_sh=""
+
+  if [[ -f "${GOOD_TRIP_DIR}/lib/common.sh" ]]; then
+    common_sh="${GOOD_TRIP_DIR}/lib/common.sh"
+  elif [[ -f "${CLI_SCRIPT_DIR}/../lib/common.sh" ]]; then
+    common_sh="${CLI_SCRIPT_DIR}/../lib/common.sh"
+  fi
+
+  if [[ -z "$common_sh" ]]; then
+    return 1
+  fi
+
+  GT_LOG_LABEL="good-trip"
+  # shellcheck source=../lib/common.sh
+  source "$common_sh"
+}
+
+bootstrap_common
+load_common || true
 
 version() {
   cat "${GOOD_TRIP_DIR}/version.txt" 2>/dev/null | tr -d '[:space:]' || echo "unknown"

--- a/bin/good-trip
+++ b/bin/good-trip
@@ -35,7 +35,7 @@ load_common() {
     return 1
   fi
 
-  GT_LOG_LABEL="good-trip"
+  export GT_LOG_LABEL="good-trip"
   # shellcheck source=../lib/common.sh
   source "$common_sh"
 }

--- a/bootstrap/install-atuin.sh
+++ b/bootstrap/install-atuin.sh
@@ -5,7 +5,7 @@
 # =============================================================================
 set -euo pipefail
 
-GT_LOG_LABEL="atuin"
+export GT_LOG_LABEL="atuin"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=../lib/common.sh
 source "${SCRIPT_DIR}/../lib/common.sh"

--- a/bootstrap/install-atuin.sh
+++ b/bootstrap/install-atuin.sh
@@ -5,12 +5,10 @@
 # =============================================================================
 set -euo pipefail
 
-GREEN='\033[0;32m'
-BLUE='\033[0;34m'
-NC='\033[0m'
-log()     { echo -e "${BLUE}[atuin]${NC} $*"; }
-success() { echo -e "${GREEN}[atuin]${NC} ✓ $*"; }
-has()     { command -v "$1" &>/dev/null; }
+GT_LOG_LABEL="atuin"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib/common.sh
+source "${SCRIPT_DIR}/../lib/common.sh"
 
 if has atuin; then
   success "Atuin already installed: $(atuin --version)"

--- a/bootstrap/install-docker.sh
+++ b/bootstrap/install-docker.sh
@@ -6,21 +6,10 @@
 # =============================================================================
 set -euo pipefail
 
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-BLUE='\033[0;34m'
-NC='\033[0m'
-log()     { echo -e "${BLUE}[docker]${NC} $*"; }
-success() { echo -e "${GREEN}[docker]${NC} ✓ $*"; }
-warn()    { echo -e "${YELLOW}[docker]${NC} ⚠ $*"; }
-has()     { command -v "$1" &>/dev/null; }
-
-# Return 0 if running inside a container (docker/containerd/podman)
-is_container() {
-  [[ -f "/.dockerenv" ]] && return 0
-  grep -qaE 'docker|kubepods|containerd|podman' /proc/1/cgroup 2>/dev/null && return 0
-  return 1
-}
+GT_LOG_LABEL="docker"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib/common.sh
+source "${SCRIPT_DIR}/../lib/common.sh"
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
 _add_to_group() {

--- a/bootstrap/install-docker.sh
+++ b/bootstrap/install-docker.sh
@@ -6,7 +6,7 @@
 # =============================================================================
 set -euo pipefail
 
-GT_LOG_LABEL="docker"
+export GT_LOG_LABEL="docker"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=../lib/common.sh
 source "${SCRIPT_DIR}/../lib/common.sh"

--- a/bootstrap/install-git-gpg.sh
+++ b/bootstrap/install-git-gpg.sh
@@ -7,7 +7,7 @@
 set -euo pipefail
 
 GOOD_TRIP_DIR="${GOOD_TRIP_DIR:-$HOME/.good-trip}"
-GT_LOG_LABEL="git-gpg"
+export GT_LOG_LABEL="git-gpg"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=../lib/common.sh
 source "${SCRIPT_DIR}/../lib/common.sh"

--- a/bootstrap/install-git-gpg.sh
+++ b/bootstrap/install-git-gpg.sh
@@ -7,15 +7,10 @@
 set -euo pipefail
 
 GOOD_TRIP_DIR="${GOOD_TRIP_DIR:-$HOME/.good-trip}"
-
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-BLUE='\033[0;34m'
-NC='\033[0m'
-log()     { echo -e "${BLUE}[git-gpg]${NC} $*"; }
-success() { echo -e "${GREEN}[git-gpg]${NC} ✓ $*"; }
-warn()    { echo -e "${YELLOW}[git-gpg]${NC} ⚠ $*"; }
-has()     { command -v "$1" &>/dev/null; }
+GT_LOG_LABEL="git-gpg"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib/common.sh
+source "${SCRIPT_DIR}/../lib/common.sh"
 
 # ── Git presence check ────────────────────────────────────────────────────────
 if ! has git; then

--- a/bootstrap/install-nvm.sh
+++ b/bootstrap/install-nvm.sh
@@ -5,7 +5,7 @@
 # =============================================================================
 set -euo pipefail
 
-GT_LOG_LABEL="nvm"
+export GT_LOG_LABEL="nvm"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=../lib/common.sh
 source "${SCRIPT_DIR}/../lib/common.sh"

--- a/bootstrap/install-nvm.sh
+++ b/bootstrap/install-nvm.sh
@@ -5,11 +5,10 @@
 # =============================================================================
 set -euo pipefail
 
-GREEN='\033[0;32m'
-BLUE='\033[0;34m'
-NC='\033[0m'
-log()     { echo -e "${BLUE}[nvm]${NC} $*"; }
-success() { echo -e "${GREEN}[nvm]${NC} ✓ $*"; }
+GT_LOG_LABEL="nvm"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib/common.sh
+source "${SCRIPT_DIR}/../lib/common.sh"
 
 NVM_DIR="${NVM_DIR:-$HOME/.nvm}"
 NVM_VERSION="${NVM_VERSION:-v0.40.1}"

--- a/bootstrap/install-ohmyzsh.sh
+++ b/bootstrap/install-ohmyzsh.sh
@@ -5,11 +5,10 @@
 # =============================================================================
 set -euo pipefail
 
-GREEN='\033[0;32m'
-BLUE='\033[0;34m'
-NC='\033[0m'
-log()     { echo -e "${BLUE}[oh-my-zsh]${NC} $*"; }
-success() { echo -e "${GREEN}[oh-my-zsh]${NC} ✓ $*"; }
+GT_LOG_LABEL="oh-my-zsh"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib/common.sh
+source "${SCRIPT_DIR}/../lib/common.sh"
 
 OMZ_DIR="${ZSH:-$HOME/.oh-my-zsh}"
 

--- a/bootstrap/install-ohmyzsh.sh
+++ b/bootstrap/install-ohmyzsh.sh
@@ -5,7 +5,7 @@
 # =============================================================================
 set -euo pipefail
 
-GT_LOG_LABEL="oh-my-zsh"
+export GT_LOG_LABEL="oh-my-zsh"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=../lib/common.sh
 source "${SCRIPT_DIR}/../lib/common.sh"

--- a/bootstrap/install-plugins.sh
+++ b/bootstrap/install-plugins.sh
@@ -5,11 +5,10 @@
 # =============================================================================
 set -euo pipefail
 
-GREEN='\033[0;32m'
-BLUE='\033[0;34m'
-NC='\033[0m'
-log()     { echo -e "${BLUE}[plugins]${NC} $*"; }
-success() { echo -e "${GREEN}[plugins]${NC} ✓ $*"; }
+GT_LOG_LABEL="plugins"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib/common.sh
+source "${SCRIPT_DIR}/../lib/common.sh"
 
 OMZ_CUSTOM="${ZSH:-$HOME/.oh-my-zsh}/custom/plugins"
 mkdir -p "$OMZ_CUSTOM"

--- a/bootstrap/install-plugins.sh
+++ b/bootstrap/install-plugins.sh
@@ -5,7 +5,7 @@
 # =============================================================================
 set -euo pipefail
 
-GT_LOG_LABEL="plugins"
+export GT_LOG_LABEL="plugins"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=../lib/common.sh
 source "${SCRIPT_DIR}/../lib/common.sh"

--- a/bootstrap/install-powerlevel10k.sh
+++ b/bootstrap/install-powerlevel10k.sh
@@ -5,7 +5,7 @@
 # =============================================================================
 set -euo pipefail
 
-GT_LOG_LABEL="p10k"
+export GT_LOG_LABEL="p10k"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=../lib/common.sh
 source "${SCRIPT_DIR}/../lib/common.sh"

--- a/bootstrap/install-powerlevel10k.sh
+++ b/bootstrap/install-powerlevel10k.sh
@@ -5,11 +5,10 @@
 # =============================================================================
 set -euo pipefail
 
-GREEN='\033[0;32m'
-BLUE='\033[0;34m'
-NC='\033[0m'
-log()     { echo -e "${BLUE}[p10k]${NC} $*"; }
-success() { echo -e "${GREEN}[p10k]${NC} ✓ $*"; }
+GT_LOG_LABEL="p10k"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib/common.sh
+source "${SCRIPT_DIR}/../lib/common.sh"
 
 OMZ_THEMES="${ZSH:-$HOME/.oh-my-zsh}/custom/themes"
 P10K_DIR="${OMZ_THEMES}/powerlevel10k"

--- a/bootstrap/install-python.sh
+++ b/bootstrap/install-python.sh
@@ -5,7 +5,7 @@
 # =============================================================================
 set -euo pipefail
 
-GT_LOG_LABEL="python"
+export GT_LOG_LABEL="python"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=../lib/common.sh
 source "${SCRIPT_DIR}/../lib/common.sh"

--- a/bootstrap/install-python.sh
+++ b/bootstrap/install-python.sh
@@ -5,17 +5,10 @@
 # =============================================================================
 set -euo pipefail
 
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-BLUE='\033[0;34m'
-NC='\033[0m'
-
-log()     { echo -e "${BLUE}[python]${NC} $*"; }
-success() { echo -e "${GREEN}[python]${NC} ✓ $*"; }
-warn()    { echo -e "${YELLOW}[python]${NC} ⚠ $*"; }
-error()   { echo -e "${RED}[python]${NC} ✗ $*" >&2; }
-has()     { command -v "$1" &>/dev/null; }
+GT_LOG_LABEL="python"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib/common.sh
+source "${SCRIPT_DIR}/../lib/common.sh"
 
 # ── Configurable defaults ─────────────────────────────────────────────────────
 # Space-separated list of pip packages to install globally after setup.

--- a/bootstrap/install-sdkman.sh
+++ b/bootstrap/install-sdkman.sh
@@ -5,7 +5,7 @@
 # =============================================================================
 set -euo pipefail
 
-GT_LOG_LABEL="sdkman"
+export GT_LOG_LABEL="sdkman"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=../lib/common.sh
 source "${SCRIPT_DIR}/../lib/common.sh"

--- a/bootstrap/install-sdkman.sh
+++ b/bootstrap/install-sdkman.sh
@@ -5,12 +5,10 @@
 # =============================================================================
 set -euo pipefail
 
-GREEN='\033[0;32m'
-BLUE='\033[0;34m'
-NC='\033[0m'
-log()     { echo -e "${BLUE}[sdkman]${NC} $*"; }
-success() { echo -e "${GREEN}[sdkman]${NC} ✓ $*"; }
-has()     { command -v "$1" &>/dev/null; }
+GT_LOG_LABEL="sdkman"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib/common.sh
+source "${SCRIPT_DIR}/../lib/common.sh"
 
 SDKMAN_DIR="${SDKMAN_DIR:-$HOME/.sdkman}"
 # Set SDKMAN_DEFAULT_JAVA to a Java identifier (e.g. "21.0.3-tem", "17.0.9-tem")
@@ -39,7 +37,7 @@ if [[ -d "$SDKMAN_DIR" ]] && [[ -s "${SDKMAN_DIR}/bin/sdkman-init.sh" ]]; then
 fi
 
 if ! has curl && ! has wget; then
-  echo "[sdkman] curl or wget required to install SDKMAN." >&2
+  error "curl or wget required to install SDKMAN."
   exit 1
 fi
 
@@ -50,7 +48,7 @@ if ! has zip; then
   elif [[ -f /etc/arch-release ]]; then
     sudo pacman -S --noconfirm zip
   else
-    echo "[sdkman] Please install zip manually before running SDKMAN." >&2
+    error "Please install zip manually before running SDKMAN."
     exit 1
   fi
 fi

--- a/bootstrap/install-zsh.sh
+++ b/bootstrap/install-zsh.sh
@@ -5,23 +5,10 @@
 # =============================================================================
 set -euo pipefail
 
-GREEN='\033[0;32m'
-BLUE='\033[0;34m'
-NC='\033[0m'
-log()     { echo -e "${BLUE}[zsh]${NC} $*"; }
-success() { echo -e "${GREEN}[zsh]${NC} ✓ $*"; }
-has()     { command -v "$1" &>/dev/null; }
-
-# Return 0 if running inside a container (docker/containerd/podman)
-is_container() {
-  if [[ -f "/.dockerenv" ]]; then
-    return 0
-  fi
-  if grep -qaE 'docker|kubepods|containerd|podman' /proc/1/cgroup 2>/dev/null; then
-    return 0
-  fi
-  return 1
-}
+GT_LOG_LABEL="zsh"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib/common.sh
+source "${SCRIPT_DIR}/../lib/common.sh"
 
 if has zsh; then
   success "ZSH already installed: $(zsh --version)"
@@ -52,7 +39,7 @@ elif [[ -f /etc/debian_version ]]; then
 elif [[ -f /etc/fedora-release ]] || [[ -f /etc/redhat-release ]]; then
   sudo dnf install -y zsh
 else
-  echo "Please install ZSH manually for your OS." >&2
+  error "Please install ZSH manually for your OS."
   exit 1
 fi
 

--- a/bootstrap/install-zsh.sh
+++ b/bootstrap/install-zsh.sh
@@ -5,7 +5,7 @@
 # =============================================================================
 set -euo pipefail
 
-GT_LOG_LABEL="zsh"
+export GT_LOG_LABEL="zsh"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=../lib/common.sh
 source "${SCRIPT_DIR}/../lib/common.sh"

--- a/install.sh
+++ b/install.sh
@@ -93,7 +93,7 @@ load_common() {
     return 1
   fi
 
-  GT_LOG_LABEL="good-trip"
+  export GT_LOG_LABEL="good-trip"
   # shellcheck source=lib/common.sh
   source "$common_sh"
 }

--- a/install.sh
+++ b/install.sh
@@ -25,31 +25,81 @@ REPO_URL="https://github.com/PepeuFBV/good-trip.git"
 GOOD_TRIP_DIR="${GOOD_TRIP_DIR:-$HOME/.good-trip}"
 GOOD_TRIP_BIN="${HOME}/.local/bin"
 LOG_FILE="${HOME}/.local/share/good-trip/install.log"
+INSTALL_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-# ── Colours ───────────────────────────────────────────────────────────────────
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-BLUE='\033[0;34m'
-CYAN='\033[0;36m'
-BOLD='\033[1m'
-DIM='\033[2m'
-NC='\033[0m'
+# install.sh also works via curl | bash before the repo exists locally, so it
+# keeps a tiny bootstrap helper set and upgrades to lib/common.sh when available.
+bootstrap_common() {
+  RED='\033[0;31m'
+  GREEN='\033[0;32m'
+  YELLOW='\033[1;33m'
+  BLUE='\033[0;34m'
+  CYAN='\033[0;36m'
+  BOLD='\033[1m'
+  DIM='\033[2m'
+  NC='\033[0m'
 
-# ── Helpers ───────────────────────────────────────────────────────────────────
-log()     { echo -e "${BLUE}[good-trip]${NC} $*"; }
-success() { echo -e "${GREEN}[good-trip]${NC} ✓ $*"; }
-warn()    { echo -e "${YELLOW}[good-trip]${NC} ⚠ $*"; }
-error()   { echo -e "${RED}[good-trip]${NC} ✗ $*" >&2; }
-die()     { error "$*"; exit 1; }
-has()     { command -v "$1" &>/dev/null; }
+  log()     { echo -e "${BLUE}[good-trip]${NC} $*"; }
+  success() { echo -e "${GREEN}[good-trip]${NC} ✓ $*"; }
+  warn()    { echo -e "${YELLOW}[good-trip]${NC} ⚠ $*"; }
+  error()   { echo -e "${RED}[good-trip]${NC} ✗ $*" >&2; }
+  die()     { error "$*"; exit 1; }
+  has()     { command -v "$1" &>/dev/null; }
 
-step() {
-  echo ""
-  echo -e "${BOLD}${BLUE}──────────────────────────────────────────${NC}"
-  echo -e "${BOLD}${BLUE}  $*${NC}"
-  echo -e "${BOLD}${BLUE}──────────────────────────────────────────${NC}"
+  step() {
+    echo ""
+    echo -e "${BOLD}${BLUE}──────────────────────────────────────────${NC}"
+    echo -e "${BOLD}${BLUE}  $*${NC}"
+    echo -e "${BOLD}${BLUE}──────────────────────────────────────────${NC}"
+  }
+
+  confirm() {
+    local prompt="${1:?prompt is required}"
+    local default="${2:-y}"
+    local answer fallback suffix
+
+    case "${default,,}" in
+      y|yes)
+        fallback="y"
+        suffix="[Y/n]"
+        ;;
+      *)
+        fallback="n"
+        suffix="[y/N]"
+        ;;
+    esac
+
+    if [[ ! -t 0 ]]; then
+      [[ "$fallback" == "y" ]]
+      return
+    fi
+
+    read -r -p "$(echo -e "${YELLOW}[good-trip]${NC} ${prompt} ${suffix} ")" answer
+    answer="${answer:-$fallback}"
+    [[ "${answer,,}" =~ ^(y|yes)$ ]]
+  }
 }
+
+load_common() {
+  local common_sh=""
+
+  if [[ -f "${INSTALL_SCRIPT_DIR}/lib/common.sh" ]]; then
+    common_sh="${INSTALL_SCRIPT_DIR}/lib/common.sh"
+  elif [[ -f "${GOOD_TRIP_DIR}/lib/common.sh" ]]; then
+    common_sh="${GOOD_TRIP_DIR}/lib/common.sh"
+  fi
+
+  if [[ -z "$common_sh" ]]; then
+    return 1
+  fi
+
+  GT_LOG_LABEL="good-trip"
+  # shellcheck source=lib/common.sh
+  source "$common_sh"
+}
+
+bootstrap_common
+load_common || true
 
 # ── Component registry ────────────────────────────────────────────────────────
 # Format: "script_name|Label|Description|default(1=on,0=off)|required(1=always)"
@@ -362,9 +412,7 @@ print_summary() {
   echo -e "    ${GREEN}✓${NC}  Symlinks  ${DIM}(always)${NC}"
   echo -e "    ${GREEN}✓${NC}  good-trip CLI  ${DIM}(always)${NC}"
   echo ""
-  read -r -p "$(echo -e "${YELLOW}[good-trip]${NC} Proceed with installation? [Y/n] ")" answer
-  answer="${answer:-y}"
-  if [[ ! "${answer,,}" =~ ^(y|yes)$ ]]; then
+  if ! confirm "Proceed with installation?" y; then
     log "Installation cancelled."
     exit 0
   fi
@@ -456,13 +504,14 @@ BANNER
   ensure_pkg_manager
 
   # Detect if running from a local clone or piped from curl
-  if [[ -f "$(dirname "${BASH_SOURCE[0]}")/version.txt" ]]; then
-    GOOD_TRIP_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  if [[ -f "${INSTALL_SCRIPT_DIR}/version.txt" ]]; then
+    GOOD_TRIP_DIR="${INSTALL_SCRIPT_DIR}"
     export GOOD_TRIP_DIR
     log "Running from local repo: ${GOOD_TRIP_DIR}"
   else
     ensure_repo
   fi
+  load_common || true
 
   # ── Run selected components ────────────────────────────────────────────────
   local installed=0

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# =============================================================================
+# good-trip — lib/common.sh
+# Shared shell helpers used by the installer, CLI, and operational scripts.
+# =============================================================================
+
+: "${GT_LOG_LABEL:=good-trip}"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+CYAN='\033[0;36m'
+BOLD='\033[1m'
+DIM='\033[2m'
+NC='\033[0m'
+
+log()     { echo -e "${BLUE}[${GT_LOG_LABEL}]${NC} $*"; }
+success() { echo -e "${GREEN}[${GT_LOG_LABEL}]${NC} ✓ $*"; }
+warn()    { echo -e "${YELLOW}[${GT_LOG_LABEL}]${NC} ⚠ $*"; }
+error()   { echo -e "${RED}[${GT_LOG_LABEL}]${NC} ✗ $*" >&2; }
+die()     { error "$*"; exit 1; }
+has()     { command -v "$1" &>/dev/null; }
+
+step() {
+  echo ""
+  echo -e "${BOLD}${BLUE}──────────────────────────────────────────${NC}"
+  echo -e "${BOLD}${BLUE}  $*${NC}"
+  echo -e "${BOLD}${BLUE}──────────────────────────────────────────${NC}"
+}
+
+confirm() {
+  local prompt="${1:?prompt is required}"
+  local default="${2:-y}"
+  local answer fallback suffix
+
+  case "${default,,}" in
+    y|yes)
+      fallback="y"
+      suffix="[Y/n]"
+      ;;
+    *)
+      fallback="n"
+      suffix="[y/N]"
+      ;;
+  esac
+
+  if [[ ! -t 0 ]]; then
+    [[ "$fallback" == "y" ]]
+    return
+  fi
+
+  read -r -p "$(echo -e "${YELLOW}[${GT_LOG_LABEL}]${NC} ${prompt} ${suffix} ")" answer
+  answer="${answer:-$fallback}"
+  [[ "${answer,,}" =~ ^(y|yes)$ ]]
+}
+
+is_container() {
+  [[ -f "/.dockerenv" ]] && return 0
+  grep -qaE 'docker|kubepods|containerd|podman' /proc/1/cgroup 2>/dev/null && return 0
+  return 1
+}

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -10,8 +10,10 @@ RED='\033[0;31m'
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
 BLUE='\033[0;34m'
+# shellcheck disable=SC2034
 CYAN='\033[0;36m'
 BOLD='\033[1m'
+# shellcheck disable=SC2034
 DIM='\033[2m'
 NC='\033[0m'
 

--- a/scripts/check-version.sh
+++ b/scripts/check-version.sh
@@ -7,7 +7,7 @@
 # =============================================================================
 
 GOOD_TRIP_DIR="${GOOD_TRIP_DIR:-$HOME/.good-trip}"
-GT_LOG_LABEL="good-trip"
+export GT_LOG_LABEL="good-trip"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=../lib/common.sh
 source "${SCRIPT_DIR}/../lib/common.sh"

--- a/scripts/check-version.sh
+++ b/scripts/check-version.sh
@@ -7,6 +7,11 @@
 # =============================================================================
 
 GOOD_TRIP_DIR="${GOOD_TRIP_DIR:-$HOME/.good-trip}"
+GT_LOG_LABEL="good-trip"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib/common.sh
+source "${SCRIPT_DIR}/../lib/common.sh"
+
 CACHE_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/good-trip"
 # Notification filename kept for external readers; not used directly in this
 # script but used by the shell startup to detect pending updates.
@@ -14,6 +19,6 @@ CACHE_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/good-trip"
 NOTIFICATION_FILE="${CACHE_DIR}/update-available"
 
 # Only run if we have network tools
-command -v curl &>/dev/null || command -v wget &>/dev/null || exit 0
+has curl || has wget || exit 0
 
 exec bash "${GOOD_TRIP_DIR}/scripts/update.sh" --check --silent

--- a/scripts/configure-git.sh
+++ b/scripts/configure-git.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 
 LOCAL_CONFIG_DIR="${HOME}/.config/good-trip"
 LOCAL_GIT_CONFIG="${LOCAL_CONFIG_DIR}/git.local"
-GT_LOG_LABEL="configure-git"
+export GT_LOG_LABEL="configure-git"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=../lib/common.sh
 source "${SCRIPT_DIR}/../lib/common.sh"

--- a/scripts/configure-git.sh
+++ b/scripts/configure-git.sh
@@ -19,21 +19,10 @@ set -euo pipefail
 
 LOCAL_CONFIG_DIR="${HOME}/.config/good-trip"
 LOCAL_GIT_CONFIG="${LOCAL_CONFIG_DIR}/git.local"
-
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-BLUE='\033[0;34m'
-CYAN='\033[0;36m'
-BOLD='\033[1m'
-DIM='\033[2m'
-NC='\033[0m'
-
-log()     { echo -e "${BLUE}[configure-git]${NC} $*"; }
-success() { echo -e "${GREEN}[configure-git]${NC} ✓ $*"; }
-warn()    { echo -e "${YELLOW}[configure-git]${NC} ⚠ $*"; }
-error()   { echo -e "${RED}[configure-git]${NC} ✗ $*" >&2; }
-has()     { command -v "$1" &>/dev/null; }
+GT_LOG_LABEL="configure-git"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib/common.sh
+source "${SCRIPT_DIR}/../lib/common.sh"
 
 # ── Argument parsing ──────────────────────────────────────────────────────────
 ARG_NAME=""

--- a/scripts/configure-p10k.sh
+++ b/scripts/configure-p10k.sh
@@ -5,7 +5,7 @@
 # =============================================================================
 set -euo pipefail
 
-GT_LOG_LABEL="p10k"
+export GT_LOG_LABEL="p10k"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=../lib/common.sh
 source "${SCRIPT_DIR}/../lib/common.sh"

--- a/scripts/configure-p10k.sh
+++ b/scripts/configure-p10k.sh
@@ -5,15 +5,10 @@
 # =============================================================================
 set -euo pipefail
 
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-BLUE='\033[0;34m'
-RED='\033[0;31m'
-NC='\033[0m'
-log()     { echo -e "${BLUE}[p10k]${NC} $*"; }
-success() { echo -e "${GREEN}[p10k]${NC} ✓ $*"; }
-warn()    { echo -e "${YELLOW}[p10k]${NC} ⚠ $*"; }
-error()   { echo -e "${RED}[p10k]${NC} ✗ $*" >&2; }
+GT_LOG_LABEL="p10k"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib/common.sh
+source "${SCRIPT_DIR}/../lib/common.sh"
 
 P10K_TARGET="$HOME/.p10k.zsh"
 

--- a/scripts/ssh-github.sh
+++ b/scripts/ssh-github.sh
@@ -17,7 +17,7 @@
 # =============================================================================
 set -euo pipefail
 
-GT_LOG_LABEL="ssh-github"
+export GT_LOG_LABEL="ssh-github"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=../lib/common.sh
 source "${SCRIPT_DIR}/../lib/common.sh"

--- a/scripts/ssh-github.sh
+++ b/scripts/ssh-github.sh
@@ -17,20 +17,10 @@
 # =============================================================================
 set -euo pipefail
 
-# ── Colours ───────────────────────────────────────────────────────────────────
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-BLUE='\033[0;34m'
-CYAN='\033[0;36m'
-BOLD='\033[1m'
-NC='\033[0m'
-
-log()     { echo -e "${BLUE}[ssh-github]${NC} $*"; }
-success() { echo -e "${GREEN}[ssh-github]${NC} ✓ $*"; }
-warn()    { echo -e "${YELLOW}[ssh-github]${NC} ⚠ $*"; }
-error()   { echo -e "${RED}[ssh-github]${NC} ✗ $*" >&2; }
-has()     { command -v "$1" &>/dev/null; }
+GT_LOG_LABEL="ssh-github"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib/common.sh
+source "${SCRIPT_DIR}/../lib/common.sh"
 
 # ── Defaults ──────────────────────────────────────────────────────────────────
 KEY_PATH="${HOME}/.ssh/id_ed25519.pub"
@@ -207,9 +197,7 @@ echo -e "  ${BOLD}File  :${NC} ${KEY_PATH}"
 echo ""
 
 if [[ -t 0 ]]; then
-  read -r -p "$(echo -e "${YELLOW}[ssh-github]${NC} Proceed? [Y/n] ")" answer
-  answer="${answer:-y}"
-  if [[ ! "${answer,,}" =~ ^(y|yes)$ ]]; then
+  if ! confirm "Proceed?" y; then
     log "Aborted."
     exit 0
   fi

--- a/scripts/ssh-keygen.sh
+++ b/scripts/ssh-keygen.sh
@@ -18,19 +18,10 @@
 # =============================================================================
 set -euo pipefail
 
-# ── Colours ───────────────────────────────────────────────────────────────────
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-BLUE='\033[0;34m'
-CYAN='\033[0;36m'
-BOLD='\033[1m'
-NC='\033[0m'
-
-log()     { echo -e "${BLUE}[ssh-keygen]${NC} $*"; }
-success() { echo -e "${GREEN}[ssh-keygen]${NC} ✓ $*"; }
-warn()    { echo -e "${YELLOW}[ssh-keygen]${NC} ⚠ $*"; }
-error()   { echo -e "${RED}[ssh-keygen]${NC} ✗ $*" >&2; }
+GT_LOG_LABEL="ssh-keygen"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib/common.sh
+source "${SCRIPT_DIR}/../lib/common.sh"
 
 # ── Defaults ──────────────────────────────────────────────────────────────────
 COMMENT="${USER:-user}@$(hostname -s 2>/dev/null || echo host)"

--- a/scripts/ssh-keygen.sh
+++ b/scripts/ssh-keygen.sh
@@ -18,7 +18,7 @@
 # =============================================================================
 set -euo pipefail
 
-GT_LOG_LABEL="ssh-keygen"
+export GT_LOG_LABEL="ssh-keygen"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=../lib/common.sh
 source "${SCRIPT_DIR}/../lib/common.sh"

--- a/scripts/symlinks.sh
+++ b/scripts/symlinks.sh
@@ -10,7 +10,7 @@ set -euo pipefail
 
 GOOD_TRIP_DIR="${GOOD_TRIP_DIR:-$HOME/.good-trip}"
 DRY_RUN=false
-GT_LOG_LABEL="symlinks"
+export GT_LOG_LABEL="symlinks"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=../lib/common.sh
 source "${SCRIPT_DIR}/../lib/common.sh"

--- a/scripts/symlinks.sh
+++ b/scripts/symlinks.sh
@@ -10,15 +10,10 @@ set -euo pipefail
 
 GOOD_TRIP_DIR="${GOOD_TRIP_DIR:-$HOME/.good-trip}"
 DRY_RUN=false
-
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-BLUE='\033[0;34m'
-NC='\033[0m'
-
-log()     { echo -e "${BLUE}[symlinks]${NC} $*"; }
-success() { echo -e "${GREEN}[symlinks]${NC} ✓ $*"; }
-warn()    { echo -e "${YELLOW}[symlinks]${NC} ⚠ $*"; }
+GT_LOG_LABEL="symlinks"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib/common.sh
+source "${SCRIPT_DIR}/../lib/common.sh"
 
 for arg in "$@"; do
   [[ "$arg" == "--dry-run" ]] && DRY_RUN=true

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -15,7 +15,7 @@ GOOD_TRIP_DIR="${GOOD_TRIP_DIR:-$HOME/.good-trip}"
 GOOD_TRIP_BIN="${HOME}/.local/bin/good-trip"
 LOG_FILE="${HOME}/.local/share/good-trip/install.log"
 CACHE_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/good-trip"
-GT_LOG_LABEL="good-trip"
+export GT_LOG_LABEL="good-trip"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=../lib/common.sh
 source "${SCRIPT_DIR}/../lib/common.sh"

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -15,19 +15,10 @@ GOOD_TRIP_DIR="${GOOD_TRIP_DIR:-$HOME/.good-trip}"
 GOOD_TRIP_BIN="${HOME}/.local/bin/good-trip"
 LOG_FILE="${HOME}/.local/share/good-trip/install.log"
 CACHE_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/good-trip"
-
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-BLUE='\033[0;34m'
-BOLD='\033[1m'
-DIM='\033[2m'
-NC='\033[0m'
-
-log()     { echo -e "${BLUE}[good-trip]${NC} $*"; }
-success() { echo -e "${GREEN}[good-trip]${NC} ✓ $*"; }
-warn()    { echo -e "${YELLOW}[good-trip]${NC} ⚠ $*"; }
-error()   { echo -e "${RED}[good-trip]${NC} ✗ $*" >&2; }
+GT_LOG_LABEL="good-trip"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib/common.sh
+source "${SCRIPT_DIR}/../lib/common.sh"
 
 # ── Flags ──────────────────────────────────────────────────────────────────────
 YES=false
@@ -47,10 +38,7 @@ ask() {
   # ask <prompt> — returns 0 (yes) or 1 (no)
   # If --yes was passed, always return 0.
   $YES && return 0
-  local answer
-  read -r -p "$(echo -e "${YELLOW}[good-trip]${NC} $1 [y/N] ")" answer
-  answer="${answer:-n}"
-  [[ "${answer,,}" =~ ^(y|yes)$ ]]
+  confirm "$1" n
 }
 
 do_remove() {

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -14,7 +14,7 @@ GOOD_TRIP_DIR="${GOOD_TRIP_DIR:-$HOME/.good-trip}"
 GOOD_TRIP_API="https://api.github.com/repos/PepeuFBV/good-trip/releases/latest"
 GOOD_TRIP_RELEASES_API="https://api.github.com/repos/PepeuFBV/good-trip/releases"
 LOCK_FILE="${GOOD_TRIP_DIR}/.version-lock"
-GT_LOG_LABEL="good-trip"
+export GT_LOG_LABEL="good-trip"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=../lib/common.sh
 source "${SCRIPT_DIR}/../lib/common.sh"

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -14,19 +14,10 @@ GOOD_TRIP_DIR="${GOOD_TRIP_DIR:-$HOME/.good-trip}"
 GOOD_TRIP_API="https://api.github.com/repos/PepeuFBV/good-trip/releases/latest"
 GOOD_TRIP_RELEASES_API="https://api.github.com/repos/PepeuFBV/good-trip/releases"
 LOCK_FILE="${GOOD_TRIP_DIR}/.version-lock"
-
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-BLUE='\033[0;34m'
-BOLD='\033[1m'
-NC='\033[0m'
-
-log()     { echo -e "${BLUE}[good-trip]${NC} $*"; }
-success() { echo -e "${GREEN}[good-trip]${NC} ✓ $*"; }
-warn()    { echo -e "${YELLOW}[good-trip]${NC} ⚠ $*"; }
-error()   { echo -e "${RED}[good-trip]${NC} ✗ $*" >&2; }
-has()     { command -v "$1" &>/dev/null; }
+GT_LOG_LABEL="good-trip"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib/common.sh
+source "${SCRIPT_DIR}/../lib/common.sh"
 
 # ── Version helpers ────────────────────────────────────────────────────────────
 local_version() {
@@ -291,9 +282,8 @@ main() {
     local do_update=false
     if [[ "$mode" == "auto" ]]; then
       do_update=true
-    else
-      read -r -p "$(echo -e "${YELLOW}[good-trip]${NC} Apply update? [y/N] ")" answer
-      [[ "${answer,,}" =~ ^(y|yes)$ ]] && do_update=true
+    elif confirm "Apply update?" n; then
+      do_update=true
     fi
 
     if $do_update; then


### PR DESCRIPTION
## Description

This PR introduces a small shared shell helper layer to reduce repeated boilerplate across the installer, CLI, operational scripts, and bootstrap installers, without changing user-facing behavior.

It adds lib/common.sh to centralize shared concerns such as colors, log/success/warn/error, die, command existence checks, confirmation helpers, step, and container detection. Existing scripts were refactored to source that shared library while preserving their current log prefixes and runtime behavior.

It also moves the three devcontainer-only helper scripts out of bootstrap/ and into `.devcontainer/scripts/`, and updates `.devcontainer/devcontainer.json` to reference the new locations. This keeps installer bootstraps and devcontainer-only setup clearly separated.

## Type of change

- [ ] `feat` — New feature (triggers minor version bump)
- [ ] `fix` — Bug fix (triggers patch version bump)
- [ ] `docs` — Documentation only
- [X] `refactor` — Code refactoring, no functional change
- [ ] `ci` — CI/CD changes
- [ ] `chore` — Maintenance tasks
- [ ] `BREAKING CHANGE` — Breaking change (triggers major version bump)

## Checklist

- [X] I followed [Conventional Commits](https://www.conventionalcommits.org/) for all commit messages
- [X] Shell scripts pass `bash -n` (no syntax errors)
- [X] Changes are idempotent (safe to run multiple times)
- [X] Tested on Linux (and macOS if applicable)
- [X] README updated if needed
