### PR TITLE
Fix/enable-dind-in-devcontainer merge

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,6 +4,9 @@
     "dockerfile": "Dockerfile",
     "context": ".."
   },
+  "features": {
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {}
+  },
   "remoteUser": "vscode",
   "workspaceFolder": "/home/vscode/workspace",
   "workspaceMount": "source=${localWorkspaceFolder},target=/home/vscode/workspace,type=bind,consistency=cached",

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,4 @@
+CHANGELOG.md
 node_modules
 dist
 build


### PR DESCRIPTION
## Description

Enable Docker-in-Docker (dind) support in the devcontainer and reorganize bootstrap scripts.

This branch:
- Enables Docker-in-Docker inside the `.devcontainer` so the devcontainer can build and run Docker containers.

## Type of change

- [X] `feat` — New feature (triggers minor version bump)
- [ ] `fix` — Bug fix (triggers patch version bump)
- [ ] `docs` — Documentation only
- [ ] `refactor` — Code refactoring, no functional change
- [ ] `ci` — CI/CD changes
- [ ] `chore` — Maintenance tasks
- [ ] `BREAKING CHANGE` — Breaking change (triggers major version bump)

## Checklist

- [x] I followed [Conventional Commits](https://www.conventionalcommits.org/) for all commit messages
- [x] Shell scripts pass `bash -n` (no syntax errors)
- [X] Changes are idempotent (safe to run multiple times)
- [x] Tested on Linux (and macOS if applicable)
- [X] README updated if needed