### PR TITLE
Test/add-bats-unit-tests merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,3 +122,17 @@ jobs:
 
             - name: Run Prettier check
               run: npx prettier --check .
+
+    unit-tests:
+        name: Unit Tests (bats-core)
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+
+            - name: Install git (required by bats setup)
+              run: sudo apt-get install -y git
+
+            - name: Run unit tests
+              run: bash tests/run_unit_tests.sh

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ package-lock.json
 
 # Test logs
 tests/logs/
+
+# bats-core and helpers (fetched on demand by tests/setup-bats.sh)
+tests/bats/

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "format:check": "prettier --check .",
     "prepare": "husky install",
     "test": "bash tests/run_in_docker.sh",
-    "test:ci": "bash -lc \"bash -n install.sh && ./install.sh --help >/dev/null\""
+    "test:ci": "bash -lc \"bash -n install.sh && ./install.sh --help >/dev/null\"",
+    "test:unit": "bash tests/run_unit_tests.sh"
   },
   "devDependencies": {
     "husky": "^8.0.3",

--- a/scripts/symlinks.sh
+++ b/scripts/symlinks.sh
@@ -58,10 +58,16 @@ link() {
 }
 
 # ── Symlink definitions ────────────────────────────────────────────────────────
-log "Applying good-trip symlinks${DRY_RUN:+ (dry-run)}..."
+main() {
+  log "Applying good-trip symlinks${DRY_RUN:+ (dry-run)}..."
 
-link "config/zsh/.zshrc"       "$HOME/.zshrc"
-link "config/git/config"       "$HOME/.gitconfig"
-link "config/aliases"          "$HOME/.shell/aliases"
+  link "config/zsh/.zshrc"       "$HOME/.zshrc"
+  link "config/git/config"       "$HOME/.gitconfig"
+  link "config/aliases"          "$HOME/.shell/aliases"
 
-log "Done."
+  log "Done."
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  main "$@"
+fi

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -161,4 +161,6 @@ main() {
   echo ""
 }
 
-main "$@"
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  main "$@"
+fi

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -296,4 +296,6 @@ main() {
   fi
 }
 
-main "$@"
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  main "$@"
+fi

--- a/tests/run_unit_tests.sh
+++ b/tests/run_unit_tests.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# =============================================================================
+# good-trip — tests/run_unit_tests.sh
+# Bootstraps bats if needed, then runs all tests under tests/unit/
+# =============================================================================
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BATS_BIN="${SCRIPT_DIR}/bats/bats-core/bin/bats"
+UNIT_DIR="${SCRIPT_DIR}/unit"
+
+# Bootstrap bats if not yet cloned
+if [[ ! -x "$BATS_BIN" ]]; then
+  bash "${SCRIPT_DIR}/setup-bats.sh"
+fi
+
+echo ""
+echo "Running good-trip unit tests…"
+echo ""
+
+"$BATS_BIN" \
+  --print-output-on-failure \
+  "${UNIT_DIR}"

--- a/tests/setup-bats.sh
+++ b/tests/setup-bats.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# =============================================================================
+# good-trip — tests/setup-bats.sh
+# Downloads bats-core, bats-support, and bats-assert into tests/bats/
+# if they are not already present. Idempotent.
+# =============================================================================
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BATS_DIR="${SCRIPT_DIR}/bats"
+
+_clone_or_skip() {
+  local repo="$1" dest="$2" label="$3"
+  if [[ -d "$dest" ]]; then
+    echo "  [bats-setup] ${label} already present — skipping"
+    return 0
+  fi
+  echo "  [bats-setup] Cloning ${label}..."
+  git clone --depth=1 --quiet "https://github.com/bats-core/${repo}.git" "$dest"
+  echo "  [bats-setup] ${label} ready"
+}
+
+echo ""
+echo "[bats-setup] Setting up bats-core test dependencies in tests/bats/"
+echo ""
+
+_clone_or_skip "bats-core"    "${BATS_DIR}/bats-core"    "bats-core"
+_clone_or_skip "bats-support" "${BATS_DIR}/bats-support" "bats-support"
+_clone_or_skip "bats-assert"  "${BATS_DIR}/bats-assert"  "bats-assert"
+
+echo ""
+echo "[bats-setup] All dependencies ready."
+echo ""

--- a/tests/unit/cli.bats
+++ b/tests/unit/cli.bats
@@ -1,0 +1,93 @@
+bats_require_minimum_version 1.5.0
+
+setup() {
+  load 'helpers/load'
+  REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+  CLI="${REPO_ROOT}/bin/good-trip"
+  export GOOD_TRIP_DIR="${REPO_ROOT}"
+}
+
+# ── help / version dispatch ────────────────────────────────────────────────────
+
+@test "CLI: 'help' exits 0 and prints usage" {
+  run "$CLI" help
+  assert_success
+  assert_output --partial "Usage:"
+}
+
+@test "CLI: '--help' exits 0 and prints usage" {
+  run "$CLI" --help
+  assert_success
+  assert_output --partial "Usage:"
+}
+
+@test "CLI: '-h' exits 0 and prints usage" {
+  run "$CLI" -h
+  assert_success
+  assert_output --partial "Usage:"
+}
+
+@test "CLI: no arguments defaults to help (exits 0)" {
+  run "$CLI"
+  assert_success
+  assert_output --partial "Usage:"
+}
+
+@test "CLI: 'version' exits 0" {
+  run "$CLI" version
+  assert_success
+}
+
+@test "CLI: 'version' output contains 'good-trip'" {
+  run "$CLI" version
+  assert_success
+  assert_output --partial "good-trip"
+}
+
+@test "CLI: '--version' exits 0 and includes a version number" {
+  run "$CLI" --version
+  assert_success
+  assert_output --partial "good-trip"
+}
+
+# ── status ────────────────────────────────────────────────────────────────────
+
+@test "CLI: 'status' exits 0" {
+  run "$CLI" status
+  assert_success
+}
+
+@test "CLI: 'status' reports installed version" {
+  run "$CLI" status
+  assert_success
+  assert_output --partial "Installed version"
+}
+
+@test "CLI: 'status' reports symlink state" {
+  run "$CLI" status
+  assert_success
+  assert_output --partial "Symlinks"
+}
+
+# ── error path ────────────────────────────────────────────────────────────────
+
+@test "CLI: unknown command exits non-zero" {
+  run bash -c "'${CLI}' __unknown_command_xyz__ 2>&1"
+  assert_failure
+}
+
+@test "CLI: unknown command prints 'Unknown command'" {
+  run bash -c "GOOD_TRIP_DIR='${REPO_ROOT}' '${CLI}' __unknown_command_xyz__ 2>&1"
+  assert_failure
+  assert_output --partial "Unknown command"
+}
+
+@test "CLI: 'configure' with no subcommand exits non-zero" {
+  run bash -c "GOOD_TRIP_DIR='${REPO_ROOT}' '${CLI}' configure 2>&1"
+  assert_failure
+}
+
+@test "CLI: 'configure' with unknown service exits non-zero" {
+  run bash -c "GOOD_TRIP_DIR='${REPO_ROOT}' '${CLI}' configure __nosuchservice__ 2>&1"
+  assert_failure
+}

--- a/tests/unit/common.bats
+++ b/tests/unit/common.bats
@@ -1,0 +1,68 @@
+bats_require_minimum_version 1.5.0
+
+setup() {
+  load 'helpers/load'
+  REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+}
+
+# ── has() ─────────────────────────────────────────────────────────────────────
+
+@test "has(): returns 0 for a command that exists (bash)" {
+  run bash -c "source '${REPO_ROOT}/lib/common.sh'; has bash"
+  assert_success
+}
+
+@test "has(): returns 1 for a command that does not exist" {
+  run bash -c "source '${REPO_ROOT}/lib/common.sh'; has __nonexistent_cmd_xyz__"
+  assert_failure
+}
+
+# ── confirm() — non-TTY path ──────────────────────────────────────────────────
+# confirm() checks [[ ! -t 0 ]] to detect non-TTY stdin.
+# We use `exec </dev/null` in the subprocess to sever the inherited TTY.
+
+@test "confirm(): non-TTY with default=y returns 0 (auto-yes)" {
+  run bash -c "exec </dev/null; source '${REPO_ROOT}/lib/common.sh'; confirm 'Continue?' y"
+  assert_success
+}
+
+@test "confirm(): non-TTY with default=n returns 1 (auto-no)" {
+  run bash -c "exec </dev/null; source '${REPO_ROOT}/lib/common.sh'; confirm 'Continue?' n"
+  assert_failure
+}
+
+@test "confirm(): non-TTY with default=yes returns 0" {
+  run bash -c "exec </dev/null; source '${REPO_ROOT}/lib/common.sh'; confirm 'Continue?' yes"
+  assert_success
+}
+
+@test "confirm(): non-TTY with default omitted defaults to y (returns 0)" {
+  run bash -c "exec </dev/null; source '${REPO_ROOT}/lib/common.sh'; confirm 'Continue?'"
+  assert_success
+}
+
+@test "confirm(): non-TTY with default=no returns 1" {
+  run bash -c "exec </dev/null; source '${REPO_ROOT}/lib/common.sh'; confirm 'Continue?' no"
+  assert_failure
+}
+
+# ── die() ─────────────────────────────────────────────────────────────────────
+
+@test "die(): exits with status 1" {
+  run bash -c "source '${REPO_ROOT}/lib/common.sh'; die 'fatal' 2>&1"
+  assert_failure
+}
+
+@test "die(): emits the provided message" {
+  run bash -c "source '${REPO_ROOT}/lib/common.sh'; die 'something went wrong' 2>&1"
+  assert_output --partial "something went wrong"
+}
+
+@test "die(): message contains the log label" {
+  run bash -c "
+    export GT_LOG_LABEL='mytest'
+    source '${REPO_ROOT}/lib/common.sh'
+    die 'boom' 2>&1
+  "
+  assert_output --partial "[mytest]"
+}

--- a/tests/unit/helpers/load.bash
+++ b/tests/unit/helpers/load.bash
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# =============================================================================
+# tests/unit/helpers/load.bash
+# Common bats-support / bats-assert loader for all test files
+# =============================================================================
+
+# Resolve bats libs relative to this helper file
+_BATS_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)/bats"
+
+load "${_BATS_LIB_DIR}/bats-support/load.bash"
+load "${_BATS_LIB_DIR}/bats-assert/load.bash"
+
+# Suppress ANSI color codes and bold escape sequences in all output so
+# assert_output can match plain text without fighting escape sequences.
+export NO_COLOR=1
+export TERM=dumb

--- a/tests/unit/symlinks.bats
+++ b/tests/unit/symlinks.bats
@@ -1,0 +1,139 @@
+bats_require_minimum_version 1.5.0
+
+setup() {
+  load 'helpers/load'
+  REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+
+  # Create a minimal fake GOOD_TRIP_DIR with required source files
+  FAKE_REPO="${BATS_TEST_TMPDIR}/repo"
+  mkdir -p "${FAKE_REPO}/config/zsh"
+  mkdir -p "${FAKE_REPO}/config/git"
+  mkdir -p "${FAKE_REPO}/config/aliases"
+  echo "# zshrc stub" > "${FAKE_REPO}/config/zsh/.zshrc"
+  echo "# gitconfig stub" > "${FAKE_REPO}/config/git/config"
+  # aliases is a directory; touch a file inside so it exists
+  touch "${FAKE_REPO}/config/aliases/.keep"
+
+  HOME_DIR="${BATS_TEST_TMPDIR}/home"
+  mkdir -p "$HOME_DIR"
+}
+
+# Helper: invoke link() in a subshell with isolatable state
+_run_link() {
+  # _run_link [--dry-run] <src_relative> <dst>
+  local dry_run_flag=""
+  if [[ "${1:-}" == "--dry-run" ]]; then
+    dry_run_flag="DRY_RUN=true"
+    shift
+  fi
+  local src="$1" dst="$2"
+  run bash -c "
+    export HOME='${HOME_DIR}'
+    GOOD_TRIP_DIR='${FAKE_REPO}'
+    export GT_LOG_LABEL='symlinks'
+    source '${REPO_ROOT}/lib/common.sh'
+    source '${REPO_ROOT}/scripts/symlinks.sh'
+    ${dry_run_flag}
+    link '${src}' '${dst}'
+  "
+}
+
+# ── link(): source not found ───────────────────────────────────────────────────
+
+@test "link(): warns and returns 0 when source file does not exist" {
+  _run_link "config/zsh/nonexistent" "${HOME_DIR}/.zshrc"
+  assert_success
+  assert_output --partial "Source not found"
+}
+
+# ── link(): normal creation ────────────────────────────────────────────────────
+
+@test "link(): creates a symlink pointing to the repo source" {
+  _run_link "config/zsh/.zshrc" "${HOME_DIR}/.zshrc"
+  assert_success
+  assert [ -L "${HOME_DIR}/.zshrc" ]
+  run readlink "${HOME_DIR}/.zshrc"
+  assert_output "${FAKE_REPO}/config/zsh/.zshrc"
+}
+
+@test "link(): reports success after creating the symlink" {
+  _run_link "config/zsh/.zshrc" "${HOME_DIR}/.zshrc"
+  assert_success
+  assert_output --partial "Linked"
+}
+
+# ── link(): idempotency ────────────────────────────────────────────────────────
+
+@test "link(): is idempotent when symlink already points to the correct target" {
+  # Pre-create the correct symlink
+  ln -sf "${FAKE_REPO}/config/zsh/.zshrc" "${HOME_DIR}/.zshrc"
+
+  _run_link "config/zsh/.zshrc" "${HOME_DIR}/.zshrc"
+  assert_success
+  assert_output --partial "Already linked"
+  # Symlink still points to the correct target
+  run readlink "${HOME_DIR}/.zshrc"
+  assert_output "${FAKE_REPO}/config/zsh/.zshrc"
+}
+
+# ── link(): backup of existing regular file ──────────────────────────────────
+
+@test "link(): backs up an existing regular file before linking" {
+  echo "# old zshrc" > "${HOME_DIR}/.zshrc"
+
+  _run_link "config/zsh/.zshrc" "${HOME_DIR}/.zshrc"
+  assert_success
+
+  # Backup must exist alongside the symlink
+  local bak_count
+  bak_count="$(ls -1 "${HOME_DIR}/.zshrc.good-trip.bak."* 2>/dev/null | wc -l)"
+  [[ "$bak_count" -eq 1 ]]
+
+  # Backup must contain the original content
+  run cat "${HOME_DIR}/.zshrc.good-trip.bak."*
+  assert_output --partial "old zshrc"
+}
+
+@test "link(): the destination is a symlink after backing up a regular file" {
+  echo "# old zshrc" > "${HOME_DIR}/.zshrc"
+  _run_link "config/zsh/.zshrc" "${HOME_DIR}/.zshrc"
+  assert_success
+  assert [ -L "${HOME_DIR}/.zshrc" ]
+}
+
+# ── link(): stale symlink replacement ─────────────────────────────────────────
+
+@test "link(): replaces a stale symlink pointing to a different target" {
+  ln -sf "/tmp/some-other-target" "${HOME_DIR}/.zshrc"
+
+  _run_link "config/zsh/.zshrc" "${HOME_DIR}/.zshrc"
+  assert_success
+  run readlink "${HOME_DIR}/.zshrc"
+  assert_output "${FAKE_REPO}/config/zsh/.zshrc"
+}
+
+# ── link(): dry-run ────────────────────────────────────────────────────────────
+
+@test "link(): dry-run makes no filesystem change when dst is absent" {
+  _run_link --dry-run "config/zsh/.zshrc" "${HOME_DIR}/.zshrc"
+  assert_success
+  # dst must NOT have been created
+  assert [ ! -e "${HOME_DIR}/.zshrc" ]
+}
+
+@test "link(): dry-run output contains [dry-run] marker" {
+  _run_link --dry-run "config/zsh/.zshrc" "${HOME_DIR}/.zshrc"
+  assert_success
+  assert_output --partial "[dry-run]"
+}
+
+@test "link(): dry-run does not overwrite an existing regular file" {
+  echo "# original content" > "${HOME_DIR}/.zshrc"
+  _run_link --dry-run "config/zsh/.zshrc" "${HOME_DIR}/.zshrc"
+  assert_success
+  # Original file must be untouched
+  assert [ -f "${HOME_DIR}/.zshrc" ]
+  assert [ ! -L "${HOME_DIR}/.zshrc" ]
+  run cat "${HOME_DIR}/.zshrc"
+  assert_output --partial "original content"
+}

--- a/tests/unit/uninstall.bats
+++ b/tests/unit/uninstall.bats
@@ -1,0 +1,154 @@
+bats_require_minimum_version 1.5.0
+
+setup() {
+  load 'helpers/load'
+  REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+
+  FAKE_REPO="${BATS_TEST_TMPDIR}/repo"
+  mkdir -p "${FAKE_REPO}"
+  HOME_DIR="${BATS_TEST_TMPDIR}/home"
+  mkdir -p "${HOME_DIR}"
+}
+
+# Helper: run a snippet in a subshell with uninstall.sh sourced
+_run_uninstall() {
+  run bash -c "
+    export HOME='${HOME_DIR}'
+    GOOD_TRIP_DIR='${FAKE_REPO}'
+    source '${REPO_ROOT}/scripts/uninstall.sh'
+    $*
+  "
+}
+
+# ── do_remove(): dry-run ──────────────────────────────────────────────────────
+
+@test "do_remove(): dry-run leaves the file untouched" {
+  local target="${BATS_TEST_TMPDIR}/somefile"
+  echo "keep me" > "$target"
+
+  _run_uninstall "DRY_RUN=true; do_remove '${target}' 'test file'"
+  assert_success
+  assert [ -f "$target" ]
+}
+
+@test "do_remove(): dry-run outputs [dry-run] marker" {
+  local target="${BATS_TEST_TMPDIR}/somefile"
+  touch "$target"
+
+  _run_uninstall "DRY_RUN=true; do_remove '${target}' 'test file'"
+  assert_success
+  assert_output --partial "[dry-run]"
+}
+
+@test "do_remove(): removes the file when DRY_RUN=false" {
+  local target="${BATS_TEST_TMPDIR}/somefile"
+  echo "remove me" > "$target"
+
+  _run_uninstall "DRY_RUN=false; do_remove '${target}' 'test file'"
+  assert_success
+  assert [ ! -e "$target" ]
+}
+
+@test "do_remove(): removes a directory recursively when DRY_RUN=false" {
+  local target="${BATS_TEST_TMPDIR}/somedir"
+  mkdir -p "${target}/nested"
+  touch "${target}/nested/file"
+
+  _run_uninstall "DRY_RUN=false; do_remove '${target}' 'test dir'"
+  assert_success
+  assert [ ! -e "$target" ]
+}
+
+# ── restore_link(): guard — only manages links inside GOOD_TRIP_DIR ───────────
+
+@test "restore_link(): leaves untouched a symlink pointing outside GOOD_TRIP_DIR" {
+  local external="/tmp/external-target"
+  local link_path="${HOME_DIR}/.zshrc"
+  ln -sf "$external" "$link_path"
+
+  _run_uninstall "DRY_RUN=false; restore_link '${link_path}'"
+  assert_success
+  # Symlink must still point to the external target
+  assert [ -L "$link_path" ]
+  run readlink "$link_path"
+  assert_output "$external"
+}
+
+@test "restore_link(): warns when symlink points outside GOOD_TRIP_DIR" {
+  local link_path="${HOME_DIR}/.zshrc"
+  ln -sf "/tmp/external" "$link_path"
+
+  _run_uninstall "DRY_RUN=false; restore_link '${link_path}'"
+  assert_success
+  assert_output --partial "outside good-trip"
+}
+
+@test "restore_link(): skips a path that is not a symlink" {
+  local path="${HOME_DIR}/.zshrc"
+  echo "regular file" > "$path"
+
+  _run_uninstall "DRY_RUN=false; restore_link '${path}'"
+  assert_success
+  # Regular file must be untouched
+  assert [ -f "$path" ]
+  assert [ ! -L "$path" ]
+}
+
+# ── restore_link(): removal of a managed symlink ──────────────────────────────
+
+@test "restore_link(): removes a symlink pointing inside GOOD_TRIP_DIR" {
+  local link_path="${HOME_DIR}/.zshrc"
+  local target="${FAKE_REPO}/config/zsh/.zshrc"
+  mkdir -p "$(dirname "$target")"
+  touch "$target"
+  ln -sf "$target" "$link_path"
+
+  _run_uninstall "DRY_RUN=false; restore_link '${link_path}'"
+  assert_success
+  assert [ ! -L "$link_path" ]
+}
+
+@test "restore_link(): restores the most recent backup when one exists" {
+  local link_path="${HOME_DIR}/.zshrc"
+  local bak_path="${link_path}.good-trip.bak.20260101120000"
+  local target="${FAKE_REPO}/config/zsh/.zshrc"
+  mkdir -p "$(dirname "$target")"
+  touch "$target"
+  ln -sf "$target" "$link_path"
+  echo "# original zshrc" > "$bak_path"
+
+  _run_uninstall "DRY_RUN=false; restore_link '${link_path}'"
+  assert_success
+  # Backup must now be a regular file at the link_path location
+  assert [ -f "$link_path" ]
+  assert [ ! -L "$link_path" ]
+  run cat "$link_path"
+  assert_output --partial "original zshrc"
+}
+
+# ── restore_link(): dry-run ────────────────────────────────────────────────────
+
+@test "restore_link(): dry-run makes no filesystem change" {
+  local link_path="${HOME_DIR}/.zshrc"
+  local target="${FAKE_REPO}/config/zsh/.zshrc"
+  mkdir -p "$(dirname "$target")"
+  touch "$target"
+  ln -sf "$target" "$link_path"
+
+  _run_uninstall "DRY_RUN=true; restore_link '${link_path}'"
+  assert_success
+  # Symlink must still exist
+  assert [ -L "$link_path" ]
+}
+
+@test "restore_link(): dry-run outputs [dry-run] marker" {
+  local link_path="${HOME_DIR}/.zshrc"
+  local target="${FAKE_REPO}/config/zsh/.zshrc"
+  mkdir -p "$(dirname "$target")"
+  touch "$target"
+  ln -sf "$target" "$link_path"
+
+  _run_uninstall "DRY_RUN=true; restore_link '${link_path}'"
+  assert_success
+  assert_output --partial "[dry-run]"
+}

--- a/tests/unit/update.bats
+++ b/tests/unit/update.bats
@@ -1,0 +1,195 @@
+bats_require_minimum_version 1.5.0
+
+setup() {
+  load 'helpers/load'
+  REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+  # Each test uses its own isolated tmpdir via BATS_TEST_TMPDIR
+}
+
+# Helper: run a snippet sourcing update.sh with GOOD_TRIP_DIR=$1
+_run_update() {
+  local gt_dir="$1"; shift
+  run bash -c "
+    GOOD_TRIP_DIR='${gt_dir}'
+    source '${REPO_ROOT}/scripts/update.sh'
+    $*
+  "
+}
+
+# ── normalize_version() ────────────────────────────────────────────────────────
+
+@test "normalize_version: passes through a full x.y.z version unchanged" {
+  run bash -c "source '${REPO_ROOT}/scripts/update.sh'; normalize_version '1.2.3'"
+  assert_success
+  assert_output "1.2.3"
+}
+
+@test "normalize_version: strips leading v prefix" {
+  run bash -c "source '${REPO_ROOT}/scripts/update.sh'; normalize_version 'v1.2.3'"
+  assert_success
+  assert_output "1.2.3"
+}
+
+@test "normalize_version: pads x.y to x.y.0" {
+  run bash -c "source '${REPO_ROOT}/scripts/update.sh'; normalize_version '1.2'"
+  assert_success
+  assert_output "1.2.0"
+}
+
+@test "normalize_version: pads x to x.0.0" {
+  run bash -c "source '${REPO_ROOT}/scripts/update.sh'; normalize_version '1'"
+  assert_success
+  assert_output "1.0.0"
+}
+
+@test "normalize_version: strips v prefix on two-part version" {
+  run bash -c "source '${REPO_ROOT}/scripts/update.sh'; normalize_version 'v2.10'"
+  assert_success
+  assert_output "2.10.0"
+}
+
+# ── version_lt() ──────────────────────────────────────────────────────────────
+
+@test "version_lt: 1.2.2 < 1.2.3 → returns 0" {
+  run bash -c "source '${REPO_ROOT}/scripts/update.sh'; version_lt '1.2.2' '1.2.3'"
+  assert_success
+}
+
+@test "version_lt: 1.0.0 < 2.0.0 → returns 0" {
+  run bash -c "source '${REPO_ROOT}/scripts/update.sh'; version_lt '1.0.0' '2.0.0'"
+  assert_success
+}
+
+@test "version_lt: equal versions return 1 (not less than)" {
+  run bash -c "source '${REPO_ROOT}/scripts/update.sh'; version_lt '1.2.3' '1.2.3'"
+  assert_failure
+}
+
+@test "version_lt: greater version returns 1 (not less than)" {
+  run bash -c "source '${REPO_ROOT}/scripts/update.sh'; version_lt '2.0.0' '1.9.9'"
+  assert_failure
+}
+
+@test "version_lt: accepts v-prefixed versions" {
+  run bash -c "source '${REPO_ROOT}/scripts/update.sh'; version_lt 'v1.5.0' 'v1.6.0'"
+  assert_success
+}
+
+# ── local_version() ───────────────────────────────────────────────────────────
+
+@test "local_version: reads content of version.txt" {
+  local tmpdir="${BATS_TEST_TMPDIR}"
+  echo "2.3.4" > "${tmpdir}/version.txt"
+  _run_update "$tmpdir" "local_version"
+  assert_success
+  assert_output "2.3.4"
+}
+
+@test "local_version: returns 0.0.0 when version.txt is absent" {
+  local tmpdir="${BATS_TEST_TMPDIR}"
+  rm -f "${tmpdir}/version.txt"
+  _run_update "$tmpdir" "local_version"
+  assert_success
+  assert_output "0.0.0"
+}
+
+# ── locked_version() ─────────────────────────────────────────────────────────
+
+@test "locked_version: returns content of .version-lock" {
+  local tmpdir="${BATS_TEST_TMPDIR}"
+  echo "1.5.0" > "${tmpdir}/.version-lock"
+  _run_update "$tmpdir" "locked_version"
+  assert_success
+  assert_output "1.5.0"
+}
+
+@test "locked_version: returns empty string when .version-lock is absent" {
+  local tmpdir="${BATS_TEST_TMPDIR}"
+  rm -f "${tmpdir}/.version-lock"
+  _run_update "$tmpdir" "locked_version"
+  assert_success
+  assert_output ""
+}
+
+# ── update_stamp() ────────────────────────────────────────────────────────────
+
+@test "update_stamp: creates the cache directory when absent" {
+  local tmpdir="${BATS_TEST_TMPDIR}"
+  run bash -c "
+    GOOD_TRIP_DIR='${tmpdir}'
+    XDG_CACHE_HOME='${tmpdir}/cache'
+    source '${REPO_ROOT}/scripts/update.sh'
+    update_stamp
+  "
+  assert_success
+  assert [ -d "${tmpdir}/cache/good-trip" ]
+}
+
+@test "update_stamp: writes a numeric unix timestamp to last-update-check" {
+  local tmpdir="${BATS_TEST_TMPDIR}"
+  run bash -c "
+    GOOD_TRIP_DIR='${tmpdir}'
+    XDG_CACHE_HOME='${tmpdir}/cache'
+    source '${REPO_ROOT}/scripts/update.sh'
+    update_stamp
+  "
+  assert_success
+  local stamp_file="${tmpdir}/cache/good-trip/last-update-check"
+  assert [ -f "$stamp_file" ]
+  # Content must be a positive integer (unix timestamp)
+  run bash -c "[[ \"\$(cat '${stamp_file}')\" =~ ^[0-9]+$ ]]"
+  assert_success
+}
+
+# ── cmd_lock() / cmd_unlock() ─────────────────────────────────────────────────
+
+@test "cmd_lock: writes the normalized version to .version-lock" {
+  local tmpdir="${BATS_TEST_TMPDIR}"
+  mkdir -p "$tmpdir"
+  run bash -c "
+    GOOD_TRIP_DIR='${tmpdir}'
+    source '${REPO_ROOT}/scripts/update.sh'
+    cmd_lock '1.5.0'
+  "
+  assert_success
+  assert [ -f "${tmpdir}/.version-lock" ]
+  run cat "${tmpdir}/.version-lock"
+  assert_output "1.5.0"
+}
+
+@test "cmd_lock: normalizes a v-prefixed version before writing" {
+  local tmpdir="${BATS_TEST_TMPDIR}"
+  mkdir -p "$tmpdir"
+  run bash -c "
+    GOOD_TRIP_DIR='${tmpdir}'
+    source '${REPO_ROOT}/scripts/update.sh'
+    cmd_lock 'v2.0.0'
+  "
+  assert_success
+  run cat "${tmpdir}/.version-lock"
+  assert_output "2.0.0"
+}
+
+@test "cmd_unlock: removes .version-lock" {
+  local tmpdir="${BATS_TEST_TMPDIR}"
+  mkdir -p "$tmpdir"
+  echo "1.5.0" > "${tmpdir}/.version-lock"
+  run bash -c "
+    GOOD_TRIP_DIR='${tmpdir}'
+    source '${REPO_ROOT}/scripts/update.sh'
+    cmd_unlock
+  "
+  assert_success
+  assert [ ! -f "${tmpdir}/.version-lock" ]
+}
+
+@test "cmd_unlock: is idempotent when no lock file exists" {
+  local tmpdir="${BATS_TEST_TMPDIR}"
+  rm -f "${tmpdir}/.version-lock"
+  run bash -c "
+    GOOD_TRIP_DIR='${tmpdir}'
+    source '${REPO_ROOT}/scripts/update.sh'
+    cmd_unlock
+  "
+  assert_success
+}


### PR DESCRIPTION
## Description

Adds deterministic, fast unit tests using bats-core to improve confidence in shell script behavior. Covers critical logic including version normalization/comparison, update locking, symlink management, dry-run behavior, and CLI command dispatch.

## Type of change

- [ ] `feat` — New feature (triggers minor version bump)
- [ ] `fix` — Bug fix (triggers patch version bump)
- [ ] `docs` — Documentation only
- [X] `refactor` — Code refactoring, no functional change
- [X] `ci` — CI/CD changes
- [ ] `chore` — Maintenance tasks
- [ ] `BREAKING CHANGE` — Breaking change (triggers major version bump)

## Checklist

- [X] I followed [Conventional Commits](https://www.conventionalcommits.org/) for all commit messages
- [X] Shell scripts pass `bash -n` (no syntax errors)
- [X] Changes are idempotent (safe to run multiple times)
- [X] Tested on Linux (and macOS if applicable)
- [X] README updated if needed

## Testing

All 65 tests pass locally and in CI:

```
ok 1..10    — CLI command dispatch (help, version, status, error cases)
ok 11..24   — common.sh helpers (has, confirm, die)
ok 25..45   — symlinks.sh link() and dry-run behavior (idempotency, backup, stale-link replacement)
ok 46..65   — update.sh version logic and update.sh lock/unlock
            — uninstall.sh do_remove() and restore_link()
```