### PR TITLE
Ci/expand-matrix-macos merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,3 +136,20 @@ jobs:
 
             - name: Run unit tests
               run: bash tests/run_unit_tests.sh
+
+    smoke-test:
+        name: Script Smoke Test (Linux)
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+
+            - name: Smoke-test install.sh syntax and --help
+              # bash -n validates syntax; --help must exit 0 without installing anything
+              run: npm run test:ci
+
+            - name: Smoke-test CLI --help
+              run: |
+                  export GOOD_TRIP_DIR="$PWD"
+                  bin/good-trip --help >/dev/null

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,6 +162,9 @@ jobs:
             - name: Checkout
               uses: actions/checkout@v4
 
+            - name: Install git (required by bats setup on macOS)
+              run: brew install git
+
             - name: Print macOS and bash versions
               run: |
                   sw_vers

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,12 @@ on:
         branches:
             - main
 
+# Cancel in-progress runs for the same ref to avoid duplicate job sets
+# when a push and a pull_request event both fire for the same branch.
+concurrency:
+    group: ci-${{ github.ref }}
+    cancel-in-progress: true
+
 jobs:
     lint-commits:
         name: Lint Commit Messages

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,3 +153,40 @@ jobs:
               run: |
                   export GOOD_TRIP_DIR="$PWD"
                   bin/good-trip --help >/dev/null
+
+    macos-validate:
+        name: macOS Validation
+        runs-on: macos-latest
+
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+
+            - name: Print macOS and bash versions
+              run: |
+                  sw_vers
+                  bash --version | head -1
+
+            - name: Syntax-check all shell scripts (macOS bash)
+              # Catches any constructs that differ between GNU bash on Linux
+              # and the bash version shipped by GitHub's macOS runner
+              run: |
+                  find . -name "*.sh" \
+                    -not -path "./.git/*" \
+                    -not -path "./node_modules/*" | \
+                    while IFS= read -r f; do
+                      bash -n "$f" || { echo "SYNTAX ERROR: $f"; exit 1; }
+                    done
+                  bash -n bin/good-trip
+
+            - name: Smoke-test install.sh --help on macOS
+              run: bash -n install.sh && ./install.sh --help >/dev/null
+
+            - name: Smoke-test CLI --help on macOS
+              run: |
+                  export GOOD_TRIP_DIR="$PWD"
+                  bin/good-trip --help >/dev/null
+
+            - name: Run unit tests on macOS (bats-core)
+              # Validates behavioral correctness under macOS bash and BSD userland
+              run: bash tests/run_unit_tests.sh

--- a/bin/good-trip
+++ b/bin/good-trip
@@ -131,18 +131,16 @@ cmd_status() {
 
   log "Symlinks:"
 
-  local -A targets=(
-    [~/.zshrc]="${GOOD_TRIP_DIR}/config/zsh/.zshrc"
-    [~/.gitconfig]="${GOOD_TRIP_DIR}/config/git/config"
-    [~/.shell/aliases]="${GOOD_TRIP_DIR}/config/aliases"
-  )
-
-  for link in "${!targets[@]}"; do
-    local expanded="${link/#\~/$HOME}"
-    if [[ -L "$expanded" ]]; then
-      echo -e "    ${GREEN}✓${NC} ${link} → $(readlink "$expanded")"
+  # Single indexed array — avoids local -A (bash 4+ only) for bash 3.2 (macOS) compatibility
+  local _paths _i _link _display
+  _paths=( "$HOME/.zshrc" "$HOME/.gitconfig" "$HOME/.shell/aliases" )
+  for _i in 0 1 2; do
+    _link="${_paths[$_i]}"
+    _display="${_link/$HOME/\~}"
+    if [[ -L "$_link" ]]; then
+      echo -e "    ${GREEN}✓${NC} ${_display} → $(readlink "$_link")"
     else
-      echo -e "    ${RED}✗${NC} ${link} (not linked)"
+      echo -e "    ${RED}✗${NC} ${_display} (not linked)"
     fi
   done
 }

--- a/install.sh
+++ b/install.sh
@@ -56,9 +56,11 @@ bootstrap_common() {
   confirm() {
     local prompt="${1:?prompt is required}"
     local default="${2:-y}"
-    local answer fallback suffix
+    local answer fallback suffix default_lc
 
-    case "${default,,}" in
+    # tr[:upper:] is used instead of ${var,,} for bash 3.2 (macOS) compatibility
+    default_lc="$(printf '%s' "$default" | tr '[:upper:]' '[:lower:]')"
+    case "$default_lc" in
       y|yes)
         fallback="y"
         suffix="[Y/n]"
@@ -76,7 +78,7 @@ bootstrap_common() {
 
     read -r -p "$(echo -e "${YELLOW}[good-trip]${NC} ${prompt} ${suffix} ")" answer
     answer="${answer:-$fallback}"
-    [[ "${answer,,}" =~ ^(y|yes)$ ]]
+    [[ "$(printf '%s' "$answer" | tr '[:upper:]' '[:lower:]')" =~ ^(y|yes)$ ]]
   }
 }
 

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -34,9 +34,11 @@ step() {
 confirm() {
   local prompt="${1:?prompt is required}"
   local default="${2:-y}"
-  local answer fallback suffix
+  local answer fallback suffix default_lc
 
-  case "${default,,}" in
+  # tr[:upper:] is used instead of ${var,,} for bash 3.2 (macOS) compatibility
+  default_lc="$(printf '%s' "$default" | tr '[:upper:]' '[:lower:]')"
+  case "$default_lc" in
     y|yes)
       fallback="y"
       suffix="[Y/n]"
@@ -54,7 +56,7 @@ confirm() {
 
   read -r -p "$(echo -e "${YELLOW}[${GT_LOG_LABEL}]${NC} ${prompt} ${suffix} ")" answer
   answer="${answer:-$fallback}"
-  [[ "${answer,,}" =~ ^(y|yes)$ ]]
+  [[ "$(printf '%s' "$answer" | tr '[:upper:]' '[:lower:]')" =~ ^(y|yes)$ ]]
 }
 
 is_container() {

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -53,12 +53,22 @@ normalize_version() {
 }
 
 version_lt() {
-  # Compare two versions after normalizing to MAJOR.MINOR.PATCH
+  # Compare two versions after normalizing to MAJOR.MINOR.PATCH.
+  # Uses pure bash arithmetic — portable on Linux and macOS (no sort -V).
   local a b na nb
   a="$1"; b="$2"
   na="$(normalize_version "$a")"
   nb="$(normalize_version "$b")"
-  [[ "$na" != "$nb" ]] && [[ "$(printf '%s\n' "$na" "$nb" | sort -V | head -1)" == "$na" ]]
+  [[ "$na" == "$nb" ]] && return 1
+  local IFS=.
+  read -r -a va <<< "$na"
+  read -r -a vb <<< "$nb"
+  local i
+  for i in 0 1 2; do
+    if (( ${va[$i]:-0} < ${vb[$i]:-0} )); then return 0; fi
+    if (( ${va[$i]:-0} > ${vb[$i]:-0} )); then return 1; fi
+  done
+  return 1
 }
 
 # ── Update stamp (used by daily auto-check) ────────────────────────────────────


### PR DESCRIPTION
## Description

This PR expands the CI pipeline to validate macOS compatibility and adds portable shell utilities.

## Type of change

- [ ] `feat` — New feature (triggers minor version bump)
- [x] `fix` — Bug fix (triggers patch version bump) — semver portability
- [ ] `docs` — Documentation only
- [ ] `refactor` — Code refactoring, no functional change
- [ ] `ci` — CI/CD changes
- [x] `chore` — Maintenance tasks
- [ ] `BREAKING CHANGE` — Breaking change (triggers major version bump)

## Checklist

- [x] I followed [Conventional Commits](https://www.conventionalcommits.org/) for all commit messages
- [x] Shell scripts pass `bash -n` (no syntax errors)
- [x] Changes are idempotent (safe to run multiple times)
- [x] Tested on Linux (macOS validation will run in CI via GitHub Actions)
- [x] README updated if needed (no README changes — CI-only, documented in workflow comments)

## Testing

- Linux job runs smoke tests and unit tests under Ubuntu bash 5.x
- macOS job runs smoke tests and unit tests under macOS bash 3.2.x, plus syntax validation
- Both validate the newly fixed `version_lt()` function indirectly via `test: cover update.sh version normalization and lock logic` bats test