### PR TITLE
Refactor/single-version-source-of-truth merge

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               run: npx semantic-release
 
-            - name: Post-release - update package.json and create shorthand tags/releases
+            - name: Post-release - create shorthand tags/releases
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                   GITHUB_REPOSITORY: ${{ github.repository }}
@@ -77,46 +77,33 @@ jobs:
                   # Resolve commit for the release tag
                   COMMIT=$(git rev-list -n1 "v$VERSION" 2>/dev/null || git rev-parse HEAD)
 
-                  # Update package.json version if present using GitHub Contents API
-                  # This avoids git pushes that could modify workflow files (no workflows permission needed)
-                  if [ -f package.json ]; then
-                      node -e "const fs=require('fs');const p=JSON.parse(fs.readFileSync('package.json'));p.version='${VERSION}';fs.writeFileSync('package.json',JSON.stringify(p,null,2)+'\n');"
-                      # encode content
-                      CONTENT=$(base64 -w 0 package.json)
-                      FILE_API="https://api.github.com/repos/${GITHUB_REPOSITORY}/contents/package.json"
-                      SHA=$(curl -s -H "Authorization: token ${GITHUB_TOKEN}" "$FILE_API?ref=main" | jq -r .sha)
-                      if [ -z "$SHA" ] || [ "$SHA" = "null" ]; then
-                          echo "package.json not found in repository or sha missing; skipping API update"
-                      else
-                          PAYLOAD=$(jq -n --arg msg "chore(release): update package.json to ${VERSION} [skip ci]" --arg cont "$CONTENT" --arg sha "$SHA" --arg name "github-actions[bot]" --arg email "41898282+github-actions[bot]@users.noreply.github.com" '{message:$msg,content:$cont,sha:$sha,branch:"main",committer:{name:$name,email:$email}}')
-                          curl -s -X PUT -H "Authorization: token ${GITHUB_TOKEN}" -H "Content-Type: application/json" -d "$PAYLOAD" "$FILE_API"
-                      fi
-                  fi
+                  REPO="$GITHUB_REPOSITORY"
+                  BODY="Alias release for v${VERSION}"
 
                   # Create/update shorthand tag v<major>
                   SHORT_MAJOR="v${MAJOR}"
                   git tag -f "$SHORT_MAJOR" "$COMMIT"
                   git push --force origin "refs/tags/$SHORT_MAJOR"
 
-                  # Create/update GitHub release for shorthand major tag
-                  REPO="$GITHUB_REPOSITORY"
-                  BODY="Alias release for v${VERSION}"
+                  # Create/update GitHub release for shorthand major tag (not marked latest)
                   existing=$(curl -s -H "Authorization: token ${GITHUB_TOKEN}" "https://api.github.com/repos/${REPO}/releases/tags/${SHORT_MAJOR}" || true)
                   if echo "$existing" | jq -e '.id' >/dev/null 2>&1; then
                       id=$(echo "$existing" | jq -r .id)
-                      curl -s -X PATCH -H "Authorization: token ${GITHUB_TOKEN}" -H "Content-Type: application/json" -d "{\"tag_name\":\"${SHORT_MAJOR}\",\"name\":\"${SHORT_MAJOR}\",\"body\":\"${BODY}\",\"make_latest\":\"true\"}" "https://api.github.com/repos/${REPO}/releases/${id}"
+                      curl -s -X PATCH -H "Authorization: token ${GITHUB_TOKEN}" -H "Content-Type: application/json" -d "{\"tag_name\":\"${SHORT_MAJOR}\",\"name\":\"${SHORT_MAJOR}\",\"body\":\"${BODY}\",\"make_latest\":\"false\"}" "https://api.github.com/repos/${REPO}/releases/${id}"
                   else
-                      curl -s -X POST -H "Authorization: token ${GITHUB_TOKEN}" -H "Content-Type: application/json" -d "{\"tag_name\":\"${SHORT_MAJOR}\",\"name\":\"${SHORT_MAJOR}\",\"body\":\"${BODY}\",\"make_latest\":\"true\"}" "https://api.github.com/repos/${REPO}/releases"
+                      curl -s -X POST -H "Authorization: token ${GITHUB_TOKEN}" -H "Content-Type: application/json" -d "{\"tag_name\":\"${SHORT_MAJOR}\",\"name\":\"${SHORT_MAJOR}\",\"body\":\"${BODY}\",\"make_latest\":\"false\"}" "https://api.github.com/repos/${REPO}/releases"
                   fi
 
                   # Also update v<major>.<minor> (e.g., v1.3) to track the latest for that minor series
                   SHORT_MINOR="v${MAJOR}.${MINOR}"
                   git tag -f "$SHORT_MINOR" "$COMMIT"
                   git push --force origin "refs/tags/$SHORT_MINOR"
+
+                  # Create/update GitHub release for shorthand minor tag (not marked latest)
                   existing2=$(curl -s -H "Authorization: token ${GITHUB_TOKEN}" "https://api.github.com/repos/${REPO}/releases/tags/${SHORT_MINOR}" || true)
                   if echo "$existing2" | jq -e '.id' >/dev/null 2>&1; then
                       id2=$(echo "$existing2" | jq -r .id)
-                      curl -s -X PATCH -H "Authorization: token ${GITHUB_TOKEN}" -H "Content-Type: application/json" -d "{\"tag_name\":\"${SHORT_MINOR}\",\"name\":\"${SHORT_MINOR}\",\"body\":\"${BODY}\",\"make_latest\":\"true\"}" "https://api.github.com/repos/${REPO}/releases/${id2}"
+                      curl -s -X PATCH -H "Authorization: token ${GITHUB_TOKEN}" -H "Content-Type: application/json" -d "{\"tag_name\":\"${SHORT_MINOR}\",\"name\":\"${SHORT_MINOR}\",\"body\":\"${BODY}\",\"make_latest\":\"false\"}" "https://api.github.com/repos/${REPO}/releases/${id2}"
                   else
-                      curl -s -X POST -H "Authorization: token ${GITHUB_TOKEN}" -H "Content-Type: application/json" -d "{\"tag_name\":\"${SHORT_MINOR}\",\"name\":\"${SHORT_MINOR}\",\"body\":\"${BODY}\",\"make_latest\":\"true\"}" "https://api.github.com/repos/${REPO}/releases"
+                      curl -s -X POST -H "Authorization: token ${GITHUB_TOKEN}" -H "Content-Type: application/json" -d "{\"tag_name\":\"${SHORT_MINOR}\",\"name\":\"${SHORT_MINOR}\",\"body\":\"${BODY}\",\"make_latest\":\"false\"}" "https://api.github.com/repos/${REPO}/releases"
                   fi

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -12,13 +12,13 @@
     [
       "@semantic-release/exec",
       {
-        "prepareCmd": "echo ${nextRelease.version} > version.txt"
+        "prepareCmd": "echo ${nextRelease.version} > version.txt && node -e \"const fs=require('fs');const p=JSON.parse(fs.readFileSync('package.json','utf8'));p.version='${nextRelease.version}';fs.writeFileSync('package.json',JSON.stringify(p,null,2)+'\\n');\""
       }
     ],
     [
       "@semantic-release/git",
       {
-        "assets": ["CHANGELOG.md", "version.txt"],
+        "assets": ["CHANGELOG.md", "version.txt", "package.json"],
         "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
       }
     ],


### PR DESCRIPTION
## Description

This PR eliminates redundant version mutation and release duplication by establishing `version.txt` as the single authoritative source of version information.

## Type of change

- [ ] `feat` — New feature (triggers minor version bump)
- [X] `fix` — Bug fix (triggers patch version bump)
- [ ] `docs` — Documentation only
- [ ] `refactor` — Code refactoring, no functional change
- [X] `ci` — CI/CD changes
- [ ] `chore` — Maintenance tasks
- [ ] `BREAKING CHANGE` — Breaking change (triggers major version bump)

## Checklist

- [X] I followed [Conventional Commits](https://www.conventionalcommits.org/) for all commit messages
- [X] Shell scripts pass `bash -n` (no syntax errors)
- [X] Changes are idempotent (safe to run multiple times)
- [X] Tested on Linux (and macOS if applicable)
- [X] README updated if needed